### PR TITLE
Fix parent context save bug. Change tests to use private context.

### DIFF
--- a/Sources/CoreDataRepository/CoreDataRepository+CRUD.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+CRUD.swift
@@ -33,7 +33,7 @@ extension CoreDataRepository {
                 object.create(from: item)
                 let result: Result<NSManagedObject, CoreDataRepositoryError> = .success(object)
                 return result
-                    .map(to: Model.RepoManaged.self, context: scratchPad)
+                    .map(to: Model.RepoManaged.self)
                     .save(context: scratchPad)
                     .map(\.asUnmanaged)
             }
@@ -55,7 +55,7 @@ extension CoreDataRepository {
                 promise(
                     Self.getObjectId(fromUrl: url, context: readContext)
                         .mapToNSManagedObject(context: readContext)
-                        .map(to: Model.RepoManaged.self, context: readContext)
+                        .map(to: Model.RepoManaged.self)
                         .map(\.asUnmanaged)
                 )
             }
@@ -83,7 +83,7 @@ extension CoreDataRepository {
                 scratchPad.transactionAuthor = transactionAuthor
                 return Self.getObjectId(fromUrl: url, context: scratchPad)
                     .mapToNSManagedObject(context: scratchPad)
-                    .map(to: Model.RepoManaged.self, context: scratchPad)
+                    .map(to: Model.RepoManaged.self)
                     .map { repoManaged -> Model.RepoManaged in
                         repoManaged.update(from: item)
                         return repoManaged

--- a/Sources/CoreDataRepository/CoreDataRepository+CRUD.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+CRUD.swift
@@ -195,7 +195,7 @@ extension CoreDataRepository {
             readContext.performAndWait {
                 let result = Self.getObjectId(fromUrl: url, context: readContext)
                     .mapToNSManagedObject(context: readContext)
-                    .map(to: T.self, context: readContext)
+                    .map(to: T.self)
                 promise(result)
             }
         }.eraseToAnyPublisher()

--- a/Tests/CoreDataRepositoryTests/AggregateRepositoryTests.swift
+++ b/Tests/CoreDataRepositoryTests/AggregateRepositoryTests.swift
@@ -34,25 +34,21 @@ final class AggregateRepositoryTests: CoreDataXCTestCase {
         Movie(id: UUID(), title: "E", releaseDate: Date(), boxOffice: 50),
     ]
     var objectIDs = [NSManagedObjectID]()
-    var _repository: CoreDataRepository?
-    var repository: CoreDataRepository { _repository! }
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        _repository = CoreDataRepository(context: viewContext)
-        objectIDs = movies.map { $0.asRepoManaged(in: self.viewContext).objectID }
-        try! viewContext.save()
+        objectIDs = try movies.map { $0.asRepoManaged(in: try self.viewContext()).objectID }
+        try viewContext().save()
     }
 
     override func tearDownWithError() throws {
         try super.tearDownWithError()
-        _repository = nil
         objectIDs = []
     }
 
     func testCountSuccess() throws {
         let exp = expectation(description: "Get count of movies from CoreData")
-        let result: AnyPublisher<[[String: Int]], CoreDataRepositoryError> = repository
+        let result: AnyPublisher<[[String: Int]], CoreDataRepositoryError> = try repository()
             .count(predicate: NSPredicate(value: true), entityDesc: RepoMovie.entity())
         var values: [[String: Int]] = []
         result.subscribe(on: backgroundQueue)
@@ -77,7 +73,7 @@ final class AggregateRepositoryTests: CoreDataXCTestCase {
     func testSumSuccess() throws {
         let exp = expectation(description: "Get sum of CoreData Movies boxOffice")
         var values: [[String: Decimal]] = []
-        let result: AnyPublisher<[[String: Decimal]], CoreDataRepositoryError> = repository.sum(
+        let result: AnyPublisher<[[String: Decimal]], CoreDataRepositoryError> = try repository().sum(
             predicate: NSPredicate(value: true),
             entityDesc: RepoMovie.entity(),
             attributeDesc: RepoMovie.entity().attributesByName.values.first(where: { $0.name == "boxOffice" })!
@@ -107,7 +103,7 @@ final class AggregateRepositoryTests: CoreDataXCTestCase {
     func testAverageSuccess() throws {
         let exp = expectation(description: "Get average of CoreData Movies boxOffice")
         var values: [[String: Decimal]] = []
-        let result: AnyPublisher<[[String: Decimal]], CoreDataRepositoryError> = repository.average(
+        let result: AnyPublisher<[[String: Decimal]], CoreDataRepositoryError> = try repository().average(
             predicate: NSPredicate(value: true),
             entityDesc: RepoMovie.entity(),
             attributeDesc: RepoMovie.entity().attributesByName.values.first(where: { $0.name == "boxOffice" })!
@@ -137,7 +133,7 @@ final class AggregateRepositoryTests: CoreDataXCTestCase {
     func testMinSuccess() throws {
         let exp = expectation(description: "Get average of CoreData Movies boxOffice")
         var values: [[String: Decimal]] = []
-        let result: AnyPublisher<[[String: Decimal]], CoreDataRepositoryError> = repository.min(
+        let result: AnyPublisher<[[String: Decimal]], CoreDataRepositoryError> = try repository().min(
             predicate: NSPredicate(value: true),
             entityDesc: RepoMovie.entity(),
             attributeDesc: RepoMovie.entity().attributesByName.values.first(where: { $0.name == "boxOffice" })!
@@ -167,7 +163,7 @@ final class AggregateRepositoryTests: CoreDataXCTestCase {
     func testMaxSuccess() throws {
         let exp = expectation(description: "Get average of CoreData Movies boxOffice")
         var values: [[String: Decimal]] = []
-        let result: AnyPublisher<[[String: Decimal]], CoreDataRepositoryError> = repository.max(
+        let result: AnyPublisher<[[String: Decimal]], CoreDataRepositoryError> = try repository().max(
             predicate: NSPredicate(value: true),
             entityDesc: RepoMovie.entity(),
             attributeDesc: RepoMovie.entity().attributesByName.values.first(where: { $0.name == "boxOffice" })!

--- a/Tests/CoreDataRepositoryTests/CoreDataXCTestCase.swift
+++ b/Tests/CoreDataRepositoryTests/CoreDataXCTestCase.swift
@@ -13,22 +13,48 @@ import XCTest
 
 class CoreDataXCTestCase: XCTestCase {
     var cancellables: Set<AnyCancellable> = []
+    var _container: NSPersistentContainer?
     var _viewContext: NSManagedObjectContext?
+    var _repositoryContext: NSManagedObjectContext?
+    var _repository: CoreDataRepository?
     let mainQueue = DispatchQueue.main
     let backgroundQueue = DispatchQueue(label: "background", qos: .userInitiated)
 
-    var viewContext: NSManagedObjectContext { _viewContext! }
+    func container() throws -> NSPersistentContainer {
+        try XCTUnwrap(_container)
+    }
+
+    func viewContext() throws -> NSManagedObjectContext {
+        try XCTUnwrap(_viewContext)
+    }
+
+    func repositoryContext() throws -> NSManagedObjectContext {
+        try XCTUnwrap(_repositoryContext)
+    }
+
+    func repository() throws -> CoreDataRepository {
+        try XCTUnwrap(_repository)
+    }
 
     override func setUpWithError() throws {
         let container = CoreDataStack.persistentContainer
+        _container = container
         _viewContext = container.viewContext
         _viewContext?.automaticallyMergesChangesFromParent = true
+        backgroundQueue.sync {
+            _repositoryContext = container.newBackgroundContext()
+            _repositoryContext?.automaticallyMergesChangesFromParent = true
+        }
+        _repository = CoreDataRepository(context: try repositoryContext())
         try super.setUpWithError()
     }
 
     override func tearDownWithError() throws {
         try super.tearDownWithError()
+        _container = nil
         _viewContext = nil
+        _repositoryContext = nil
+        _repository = nil
         cancellables.forEach { $0.cancel() }
     }
 }

--- a/Tests/CoreDataRepositoryTests/FetchRepositoryTests.swift
+++ b/Tests/CoreDataRepositoryTests/FetchRepositoryTests.swift
@@ -96,12 +96,12 @@ final class FetchRepositoryTests: CoreDataXCTestCase {
             })
             .store(in: &cancellables)
         wait(for: [firstExp], timeout: 5)
-        try viewContext().performAndWait {
+        try repositoryContext().performAndWait {
             do {
                 let objectId = try container().persistentStoreCoordinator
                     .managedObjectID(forURIRepresentation: try XCTUnwrap(expectedMovies.last?.url))
-                try viewContext().delete(try viewContext().object(with: try XCTUnwrap(objectId)))
-                try viewContext().save()
+                try repositoryContext().delete(try repositoryContext().object(with: try XCTUnwrap(objectId)))
+                try repositoryContext().save()
             } catch {
                 XCTFail("Failed to update repository: \(error.localizedDescription)")
             }

--- a/Tests/CoreDataRepositoryTests/FetchRepositoryTests.swift
+++ b/Tests/CoreDataRepositoryTests/FetchRepositoryTests.swift
@@ -42,7 +42,6 @@ final class FetchRepositoryTests: CoreDataXCTestCase {
             } catch {
                 XCTFail("Failed to setup context")
             }
-            
         }
     }
 

--- a/Tests/CoreDataRepositoryTests/FetchRepositoryTests.swift
+++ b/Tests/CoreDataRepositoryTests/FetchRepositoryTests.swift
@@ -34,9 +34,16 @@ final class FetchRepositoryTests: CoreDataXCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        _ = try movies.map { $0.asRepoManaged(in: try viewContext()) }
-        try viewContext().save()
-        expectedMovies = try viewContext().fetch(fetchRequest).map(\.asUnmanaged)
+        try repositoryContext().performAndWait {
+            do {
+                _ = try movies.map { $0.asRepoManaged(in: try repositoryContext()) }
+                try repositoryContext().save()
+                expectedMovies = try repositoryContext().fetch(fetchRequest).map(\.asUnmanaged)
+            } catch {
+                XCTFail("Failed to setup context")
+            }
+            
+        }
     }
 
     override func tearDownWithError() throws {


### PR DESCRIPTION
- Fix `Result.save(context:)` to save parent context in `performAndWait` closure.
- Change tests to use private context for repository
- Fix testFetchSubscription to make edits in repositoryContext