### PR TITLE
Bugfix/create returns items with temporary objectids

### DIFF
--- a/Sources/CoreDataRepository/CoreDataRepository+CRUD.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+CRUD.swift
@@ -34,6 +34,7 @@ extension CoreDataRepository {
             try context.performAndWait {
                 try context.save()
             }
+            try scratchPad.obtainPermanentIDs(for: [object])
             return object.asUnmanaged
         }
     }

--- a/Tests/CoreDataRepositoryTests/BatchRepositoryTests.swift
+++ b/Tests/CoreDataRepositoryTests/BatchRepositoryTests.swift
@@ -116,6 +116,10 @@ final class BatchRepositoryTests: CoreDataXCTestCase {
         XCTAssertEqual(result.success.count, newMovies.count)
         XCTAssertEqual(result.failed.count, 0)
 
+        for movie in result.success {
+            try await verify(movie)
+        }
+
         try await repositoryContext().perform {
             let data = try self.repositoryContext().fetch(fetchRequest)
             XCTAssertEqual(

--- a/Tests/CoreDataRepositoryTests/CRUDRepositoryTests.swift
+++ b/Tests/CoreDataRepositoryTests/CRUDRepositoryTests.swift
@@ -16,15 +16,16 @@ final class CRUDRepositoryTests: CoreDataXCTestCase {
     func testCreateSuccess() async throws {
         let movie = Movie(id: UUID(), title: "Create Success", releaseDate: Date(), boxOffice: 100)
         let result: Result<Movie, CoreDataRepositoryError> = try await repository().create(movie)
-        guard case var .success(resultMovie) = result else {
+        guard case let .success(resultMovie) = result else {
             XCTFail("Not expecting a failed result")
             return
         }
+        var tempResultMovie = resultMovie
+        XCTAssertNotNil(tempResultMovie.url)
+        tempResultMovie.url = nil
+        XCTAssertNoDifference(tempResultMovie, movie)
 
-        XCTAssertNotNil(resultMovie.url)
-        resultMovie.url = nil
-        let diff = CustomDump.diff(resultMovie, movie)
-        XCTAssertNil(diff)
+        try await verify(resultMovie)
     }
 
     func testReadSuccess() async throws {
@@ -39,15 +40,18 @@ final class CRUDRepositoryTests: CoreDataXCTestCase {
         let result: Result<Movie, CoreDataRepositoryError> = try await repository()
             .read(try XCTUnwrap(createdMovie.url))
 
-        guard case var .success(resultMovie) = result else {
+        guard case let .success(resultMovie) = result else {
             XCTFail("Not expecting a failed result")
             return
         }
 
-        XCTAssertNotNil(resultMovie.url)
-        resultMovie.url = nil
-        let diff = CustomDump.diff(resultMovie, movie)
-        XCTAssertNil(diff)
+        var tempResultMovie = resultMovie
+
+        XCTAssertNotNil(tempResultMovie.url)
+        tempResultMovie.url = nil
+        XCTAssertNoDifference(tempResultMovie, movie)
+
+        try await verify(resultMovie)
     }
 
     func testReadFailure() async throws {
@@ -91,15 +95,18 @@ final class CRUDRepositoryTests: CoreDataXCTestCase {
         let result: Result<Movie, CoreDataRepositoryError> = try await repository()
             .update(try XCTUnwrap(createdMovie.url), with: movie)
 
-        guard case var .success(resultMovie) = result else {
+        guard case let .success(resultMovie) = result else {
             XCTFail("Not expecting a failed result")
             return
         }
 
-        XCTAssertNotNil(resultMovie.url)
-        resultMovie.url = nil
-        let diff = CustomDump.diff(resultMovie, movie)
-        XCTAssertNil(diff)
+        var tempResultMovie = resultMovie
+
+        XCTAssertNotNil(tempResultMovie.url)
+        tempResultMovie.url = nil
+        XCTAssertNoDifference(tempResultMovie, movie)
+
+        try await verify(resultMovie)
     }
 
     func testUpdateFailure() async throws {

--- a/Tests/CoreDataRepositoryTests/CoreDataXCTestCase.swift
+++ b/Tests/CoreDataRepositoryTests/CoreDataXCTestCase.swift
@@ -9,6 +9,7 @@
 import Combine
 import CoreData
 import CoreDataRepository
+import CustomDump
 import XCTest
 
 class CoreDataXCTestCase: XCTestCase {
@@ -48,5 +49,41 @@ class CoreDataXCTestCase: XCTestCase {
         _repositoryContext = nil
         _repository = nil
         cancellables.forEach { $0.cancel() }
+    }
+
+    func verify<T>(_ item: T) async throws where T: UnmanagedModel {
+        guard let url = item.managedRepoUrl else {
+            XCTFail("Failed to verify item in store because it has no URL")
+            return
+        }
+
+        let context = try repositoryContext()
+        let coordinator = try container().persistentStoreCoordinator
+        context.performAndWait {
+            guard let objectID = coordinator.managedObjectID(forURIRepresentation: url) else {
+                XCTFail("Failed to verify item in store because no NSManagedObjectID found in viewContext from URL.")
+                return
+            }
+            var _object: NSManagedObject?
+            do {
+                _object = try context.existingObject(with: objectID)
+            } catch {
+                XCTFail(
+                    "Failed to verify item in store because it was not found by its NSManagedObjectID. Error: \(error.localizedDescription)"
+                )
+                return
+            }
+
+            guard let object = _object else {
+                XCTFail("Failed to verify item in store because it was not found by its NSManagedObjectID")
+                return
+            }
+
+            guard let managedItem = object as? T.RepoManaged else {
+                XCTFail("Failed to verify item in store because it failed to cast to RepoManaged type.")
+                return
+            }
+            XCTAssertNoDifference(item, managedItem.asUnmanaged)
+        }
     }
 }


### PR DESCRIPTION
- Add save of repository's context after scratchpad save in mutating CRUD endpoints
- Add call to `scratchPad.obtainPermanentIDs` in CRUD create before mapping to unmanaged.
- Add `CoreDataXCTestCase.verify` helper to more thoroughly check the store for an object after creation or mutation.