### PR TITLE
Aggregate fetchrequest does not apply predicate

### DIFF
--- a/Sources/CoreDataRepository/CoreDataRepository+Aggregate.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+Aggregate.swift
@@ -25,13 +25,14 @@ extension CoreDataRepository {
 
     private func request(
         function: AggregateFunction,
-        predicate _: NSPredicate,
+        predicate: NSPredicate,
         entityDesc: NSEntityDescription,
         attributeDesc: NSAttributeDescription,
         groupBy: NSAttributeDescription? = nil
     ) -> NSFetchRequest<NSDictionary> {
         let expDesc = NSExpressionDescription.aggregate(function: function, attributeDesc: attributeDesc)
         let request = NSFetchRequest<NSDictionary>(entityName: entityDesc.managedObjectClassName)
+        request.predicate = predicate
         request.entity = entityDesc
         request.returnsObjectsAsFaults = false
         request.resultType = .dictionaryResultType

--- a/Tests/CoreDataRepositoryTests/AggregateRepositoryTests.swift
+++ b/Tests/CoreDataRepositoryTests/AggregateRepositoryTests.swift
@@ -135,4 +135,48 @@ final class AggregateRepositoryTests: CoreDataXCTestCase {
             XCTFail("Not expecting failure")
         }
     }
+
+    func testCountWithPredicate() async throws {
+        let result: Result<[[String: Int]], CoreDataRepositoryError> = try await repository()
+            .count(predicate: NSComparisonPredicate(
+                leftExpression: NSExpression(forKeyPath: \RepoMovie.title),
+                rightExpression: NSExpression(forConstantValue: "A"),
+                modifier: .direct,
+                type: .notEqualTo
+            ), entityDesc: RepoMovie.entity())
+        switch result {
+        case let .success(values):
+            let firstValue = try XCTUnwrap(values.first?.values.first)
+            XCTAssertEqual(firstValue, 4, "Result value (count) should equal number of movies not titled 'A'.")
+        case .failure:
+            XCTFail("Not expecting failure")
+        }
+    }
+
+    func testSumWithPredicate() async throws {
+        let result: Result<[[String: Decimal]], CoreDataRepositoryError> = try await repository().sum(
+            predicate: NSComparisonPredicate(
+                leftExpression: NSExpression(forKeyPath: \RepoMovie.title),
+                rightExpression: NSExpression(forConstantValue: "A"),
+                modifier: .direct,
+                type: .notEqualTo
+            ),
+            entityDesc: RepoMovie.entity(),
+            attributeDesc: XCTUnwrap(
+                RepoMovie.entity().attributesByName.values
+                    .first(where: { $0.name == "boxOffice" })
+            )
+        )
+        switch result {
+        case let .success(values):
+            let firstValue = try XCTUnwrap(values.first?.values.first)
+            XCTAssertEqual(
+                firstValue,
+                140,
+                "Result value should equal sum of movies box office that are not titled 'A'."
+            )
+        case .failure:
+            XCTFail("Not expecting failure")
+        }
+    }
 }


### PR DESCRIPTION
- Set predicate for aggregate requests on fetchrequest
- Add test cases to check that aggregate functions use their provided predicate