### PR TITLE
Transaction author is not applied to the context for some functions

### DIFF
--- a/Sources/CoreDataRepository/CoreDataRepository+Batch.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+Batch.swift
@@ -22,11 +22,13 @@ extension CoreDataRepository {
         _ request: NSBatchInsertRequest,
         transactionAuthor: String? = nil
     ) async -> Result<NSBatchInsertResult, CoreDataRepositoryError> {
-        await context.performInScratchPad { scratchPad in
-            scratchPad.transactionAuthor = transactionAuthor
+        await context.performInScratchPad { [context] scratchPad in
+            context.transactionAuthor = transactionAuthor
             guard let result = try scratchPad.execute(request) as? NSBatchInsertResult else {
+                context.transactionAuthor = nil
                 throw CoreDataRepositoryError.fetchedObjectFailedToCastToExpectedType
             }
+            context.transactionAuthor = nil
             return result
         }
     }
@@ -127,11 +129,13 @@ extension CoreDataRepository {
         _ request: NSBatchUpdateRequest,
         transactionAuthor: String? = nil
     ) async -> Result<NSBatchUpdateResult, CoreDataRepositoryError> {
-        await context.performInScratchPad { scratchPad in
-            scratchPad.transactionAuthor = transactionAuthor
+        await context.performInScratchPad { [context] scratchPad in
+            context.transactionAuthor = transactionAuthor
             guard let result = try scratchPad.execute(request) as? NSBatchUpdateResult else {
+                context.transactionAuthor = nil
                 throw CoreDataRepositoryError.fetchedObjectFailedToCastToExpectedType
             }
+            context.transactionAuthor = nil
             return result
         }
     }
@@ -193,11 +197,13 @@ extension CoreDataRepository {
         _ request: NSBatchDeleteRequest,
         transactionAuthor: String? = nil
     ) async -> Result<NSBatchDeleteResult, CoreDataRepositoryError> {
-        await context.performInScratchPad { scratchPad in
-            scratchPad.transactionAuthor = transactionAuthor
+        await context.performInScratchPad { [context] scratchPad in
+            context.transactionAuthor = transactionAuthor
             guard let result = try scratchPad.execute(request) as? NSBatchDeleteResult else {
+                context.transactionAuthor = nil
                 throw CoreDataRepositoryError.fetchedObjectFailedToCastToExpectedType
             }
+            context.transactionAuthor = nil
             return result
         }
     }

--- a/Tests/CoreDataRepositoryTests/CRUDRepositoryTests.swift
+++ b/Tests/CoreDataRepositoryTests/CRUDRepositoryTests.swift
@@ -14,8 +14,11 @@ import XCTest
 
 final class CRUDRepositoryTests: CoreDataXCTestCase {
     func testCreateSuccess() async throws {
+        let historyTimeStamp = Date()
+        let transactionAuthor: String = #function
         let movie = Movie(id: UUID(), title: "Create Success", releaseDate: Date(), boxOffice: 100)
-        let result: Result<Movie, CoreDataRepositoryError> = try await repository().create(movie)
+        let result: Result<Movie, CoreDataRepositoryError> = try await repository()
+            .create(movie, transactionAuthor: transactionAuthor)
         guard case let .success(resultMovie) = result else {
             XCTFail("Not expecting a failed result")
             return
@@ -26,6 +29,7 @@ final class CRUDRepositoryTests: CoreDataXCTestCase {
         XCTAssertNoDifference(tempResultMovie, movie)
 
         try await verify(resultMovie)
+        try verify(transactionAuthor: transactionAuthor, timeStamp: historyTimeStamp)
     }
 
     func testReadSuccess() async throws {
@@ -92,8 +96,11 @@ final class CRUDRepositoryTests: CoreDataXCTestCase {
 
         movie.title = "Update Success - Edited"
 
+        let historyTimeStamp = Date()
+        let transactionAuthor: String = #function
+
         let result: Result<Movie, CoreDataRepositoryError> = try await repository()
-            .update(XCTUnwrap(createdMovie.url), with: movie)
+            .update(XCTUnwrap(createdMovie.url), with: movie, transactionAuthor: transactionAuthor)
 
         guard case let .success(resultMovie) = result else {
             XCTFail("Not expecting a failed result")
@@ -107,6 +114,7 @@ final class CRUDRepositoryTests: CoreDataXCTestCase {
         XCTAssertNoDifference(tempResultMovie, movie)
 
         try await verify(resultMovie)
+        try verify(transactionAuthor: transactionAuthor, timeStamp: historyTimeStamp)
     }
 
     func testUpdateFailure() async throws {
@@ -148,8 +156,11 @@ final class CRUDRepositoryTests: CoreDataXCTestCase {
             return object.asUnmanaged
         }
 
+        let historyTimeStamp = Date()
+        let transactionAuthor: String = #function
+
         let result: Result<Void, CoreDataRepositoryError> = try await repository()
-            .delete(XCTUnwrap(createdMovie.url))
+            .delete(XCTUnwrap(createdMovie.url), transactionAuthor: transactionAuthor)
 
         switch result {
         case .success:
@@ -157,6 +168,8 @@ final class CRUDRepositoryTests: CoreDataXCTestCase {
         case .failure:
             XCTFail("Not expecting a failed result")
         }
+
+        try verify(transactionAuthor: transactionAuthor, timeStamp: historyTimeStamp)
     }
 
     func testDeleteFailure() async throws {

--- a/Tests/CoreDataRepositoryTests/CoreDataStack.swift
+++ b/Tests/CoreDataRepositoryTests/CoreDataStack.swift
@@ -17,6 +17,7 @@ class CoreDataStack: NSObject {
 
     static var persistentContainer: NSPersistentContainer {
         let desc = NSPersistentStoreDescription()
+        desc.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
         desc.type = NSSQLiteStoreType // NSInMemoryStoreType
         desc.shouldAddStoreAsynchronously = false
         let model = Self.model

--- a/Tests/CoreDataRepositoryTests/CoreDataXCTestCase.swift
+++ b/Tests/CoreDataRepositoryTests/CoreDataXCTestCase.swift
@@ -86,4 +86,16 @@ class CoreDataXCTestCase: XCTestCase {
             XCTAssertNoDifference(item, managedItem.asUnmanaged)
         }
     }
+
+    func verify(transactionAuthor: String?, timeStamp: Date) throws {
+        let historyRequest = NSPersistentHistoryChangeRequest.fetchHistory(after: timeStamp)
+        try repositoryContext().performAndWait {
+            let historyResult = try XCTUnwrap(repositoryContext().execute(historyRequest) as? NSPersistentHistoryResult)
+            let history = try XCTUnwrap(historyResult.result as? [NSPersistentHistoryTransaction])
+            XCTAssertGreaterThan(history.count, 0)
+            history.forEach { historyTransaction in
+                XCTAssertEqual(historyTransaction.author, transactionAuthor)
+            }
+        }
+    }
 }


### PR DESCRIPTION
- Fix application of transactionAuthor to repository context in all editing functions
- Update tests to verify transactionAuthor is present in history when used