### PR TITLE
Accidental transaction author parameter on batch read

### DIFF
--- a/Sources/CoreDataRepository/CoreDataRepository+Batch.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+Batch.swift
@@ -82,10 +82,50 @@ extension CoreDataRepository {
     ///     - urls: [URL]
     /// - Returns
     ///     - (success: [Model, failed: [Model])
+    @available(*, deprecated, message: "This method has an unused parameter for transactionAuthor.")
     public func read<Model: UnmanagedModel>(
         urls: [URL],
         transactionAuthor _: String? = nil
     ) async -> (success: [Model], failed: [URL]) {
+        var successes = [Model]()
+        var failures = [URL]()
+        await withTaskGroup(of: _Result<Model, URL>.self, body: { [weak self] group in
+            guard let self = self else {
+                group.cancelAll()
+                return
+            }
+            for url in urls {
+                let added = group.addTaskUnlessCancelled {
+                    async let result: Result<Model, CoreDataRepositoryError> = self.read(url)
+                    switch await result {
+                    case let .success(created):
+                        return _Result<Model, URL>.success(created)
+                    case .failure:
+                        return _Result<Model, URL>.failure(url)
+                    }
+                }
+                if !added {
+                    return
+                }
+            }
+            for await result in group {
+                switch result {
+                case let .success(success):
+                    successes.append(success)
+                case let .failure(failure):
+                    failures.append(failure)
+                }
+            }
+        })
+        return (success: successes, failed: failures)
+    }
+
+    /// Batch update objects in CoreData
+    /// - Parameters
+    ///     - urls: [URL]
+    /// - Returns
+    ///     - (success: [Model, failed: [Model])
+    public func read<Model: UnmanagedModel>(urls: [URL]) async -> (success: [Model], failed: [URL]) {
         var successes = [Model]()
         var failures = [URL]()
         await withTaskGroup(of: _Result<Model, URL>.self, body: { [weak self] group in

--- a/Sources/CoreDataRepository/CoreDataRepository+Batch.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+Batch.swift
@@ -87,37 +87,7 @@ extension CoreDataRepository {
         urls: [URL],
         transactionAuthor _: String? = nil
     ) async -> (success: [Model], failed: [URL]) {
-        var successes = [Model]()
-        var failures = [URL]()
-        await withTaskGroup(of: _Result<Model, URL>.self, body: { [weak self] group in
-            guard let self = self else {
-                group.cancelAll()
-                return
-            }
-            for url in urls {
-                let added = group.addTaskUnlessCancelled {
-                    async let result: Result<Model, CoreDataRepositoryError> = self.read(url)
-                    switch await result {
-                    case let .success(created):
-                        return _Result<Model, URL>.success(created)
-                    case .failure:
-                        return _Result<Model, URL>.failure(url)
-                    }
-                }
-                if !added {
-                    return
-                }
-            }
-            for await result in group {
-                switch result {
-                case let .success(success):
-                    successes.append(success)
-                case let .failure(failure):
-                    failures.append(failure)
-                }
-            }
-        })
-        return (success: successes, failed: failures)
+        await read(urls: urls)
     }
 
     /// Batch update objects in CoreData

--- a/Tests/CoreDataRepositoryTests/BatchRepositoryTests.swift
+++ b/Tests/CoreDataRepositoryTests/BatchRepositoryTests.swift
@@ -141,7 +141,7 @@ final class BatchRepositoryTests: CoreDataXCTestCase {
 
         try verify(transactionAuthor: transactionAuthor, timeStamp: historyTimeStamp)
     }
-    
+
     func testDeprecatedReadSuccess() async throws {
         let fetchRequest = NSFetchRequest<RepoMovie>(entityName: "RepoMovie")
         var movies = [Movie]()
@@ -155,7 +155,8 @@ final class BatchRepositoryTests: CoreDataXCTestCase {
             movies = repoMovies.map(\.asUnmanaged)
         }
 
-        let result: (success: [Movie], failed: [URL]) = try await repository().read(urls: movies.compactMap(\.url), transactionAuthor: "Unused")
+        let result: (success: [Movie], failed: [URL]) = try await repository()
+            .read(urls: movies.compactMap(\.url), transactionAuthor: "Unused")
 
         XCTAssertEqual(result.success.count, movies.count)
         XCTAssertEqual(result.failed.count, 0)

--- a/Tests/CoreDataRepositoryTests/BatchRepositoryTests.swift
+++ b/Tests/CoreDataRepositoryTests/BatchRepositoryTests.swift
@@ -141,6 +141,27 @@ final class BatchRepositoryTests: CoreDataXCTestCase {
 
         try verify(transactionAuthor: transactionAuthor, timeStamp: historyTimeStamp)
     }
+    
+    func testDeprecatedReadSuccess() async throws {
+        let fetchRequest = NSFetchRequest<RepoMovie>(entityName: "RepoMovie")
+        var movies = [Movie]()
+        try await repositoryContext().perform {
+            let count = try self.repositoryContext().count(for: fetchRequest)
+            XCTAssertEqual(count, 0, "Count of objects in CoreData should be zero at the start of each test.")
+
+            let repoMovies = try self.movies
+                .map(self.mapDictToRepoMovie(_:))
+            try self.repositoryContext().save()
+            movies = repoMovies.map(\.asUnmanaged)
+        }
+
+        let result: (success: [Movie], failed: [URL]) = try await repository().read(urls: movies.compactMap(\.url), transactionAuthor: "Unused")
+
+        XCTAssertEqual(result.success.count, movies.count)
+        XCTAssertEqual(result.failed.count, 0)
+
+        XCTAssertEqual(Set(movies), Set(result.success))
+    }
 
     func testReadSuccess() async throws {
         let fetchRequest = NSFetchRequest<RepoMovie>(entityName: "RepoMovie")


### PR DESCRIPTION
- Deprecate batch read with unused transactionAuthor. Add batch read with no transactionAuthor parameter.