### PR TITLE
Strict concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
             xcode: 14.2 # Swift 5.7
           - os: macos-13
             xcode: 14.3 # Swift 5.8
+          - os: macos-13
+            xcode: '15.0' # Swift 5.9
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.8
 
 import PackageDescription
 
@@ -35,3 +35,14 @@ let package = Package(
         ),
     ]
 )
+
+package.targets.strictConcurrency()
+
+extension Array where Element == Target {
+    func strictConcurrency() {
+        forEach { target in
+            target.swiftSettings = (target.swiftSettings ?? [])
+                + [.enableUpcomingFeature("StrictConcurrency")]
+        }
+    }
+}

--- a/Tests/CoreDataRepositoryTests/BatchRepositoryTests.swift
+++ b/Tests/CoreDataRepositoryTests/BatchRepositoryTests.swift
@@ -156,7 +156,7 @@ final class BatchRepositoryTests: CoreDataXCTestCase {
         }
 
         let result: (success: [Movie], failed: [URL]) = try await repository()
-            .read(urls: movies.compactMap(\.url), transactionAuthor: "Unused")
+            .read(urls: movies.compactMap(\.url))
 
         XCTAssertEqual(result.success.count, movies.count)
         XCTAssertEqual(result.failed.count, 0)

--- a/Tests/CoreDataRepositoryTests/CRUDRepositoryTests.swift
+++ b/Tests/CoreDataRepositoryTests/CRUDRepositoryTests.swift
@@ -253,7 +253,7 @@ final class CRUDRepositoryTests: CoreDataXCTestCase {
 
             })
             .store(in: &cancellables)
-        await fulfillment(of: [firstExp], timeout: 5)
+        wait(for: [firstExp], timeout: 5)
         try repositoryContext().performAndWait { [self] in
             let coordinator = try XCTUnwrap(repositoryContext().persistentStoreCoordinator)
             let objectId = try XCTUnwrap(coordinator.managedObjectID(forURIRepresentation: XCTUnwrap(movie.url)))
@@ -261,6 +261,6 @@ final class CRUDRepositoryTests: CoreDataXCTestCase {
             object.update(from: editedMovie)
             try repositoryContext().save()
         }
-        await fulfillment(of: [secondExp], timeout: 5)
+        wait(for: [secondExp], timeout: 5)
     }
 }

--- a/Tests/CoreDataRepositoryTests/CRUDRepositoryTests.swift
+++ b/Tests/CoreDataRepositoryTests/CRUDRepositoryTests.swift
@@ -253,7 +253,7 @@ final class CRUDRepositoryTests: CoreDataXCTestCase {
 
             })
             .store(in: &cancellables)
-        wait(for: [firstExp], timeout: 5)
+        await fulfillment(of: [firstExp], timeout: 5)
         try repositoryContext().performAndWait { [self] in
             let coordinator = try XCTUnwrap(repositoryContext().persistentStoreCoordinator)
             let objectId = try XCTUnwrap(coordinator.managedObjectID(forURIRepresentation: XCTUnwrap(movie.url)))
@@ -261,6 +261,6 @@ final class CRUDRepositoryTests: CoreDataXCTestCase {
             object.update(from: editedMovie)
             try repositoryContext().save()
         }
-        wait(for: [secondExp], timeout: 5)
+        await fulfillment(of: [secondExp], timeout: 5)
     }
 }

--- a/Tests/CoreDataRepositoryTests/FetchRepositoryTests.swift
+++ b/Tests/CoreDataRepositoryTests/FetchRepositoryTests.swift
@@ -83,7 +83,7 @@ final class FetchRepositoryTests: CoreDataXCTestCase {
 
             })
             .store(in: &cancellables)
-        await fulfillment(of: [firstExp], timeout: 5)
+        wait(for: [firstExp], timeout: 5)
         let crudRepository = try CoreDataRepository(context: repositoryContext())
         _ = try await repositoryContext().perform { [self] in
             let url = try XCTUnwrap(expectedMovies.last?.url)
@@ -95,6 +95,6 @@ final class FetchRepositoryTests: CoreDataXCTestCase {
         }
         let _: Result<Void, CoreDataRepositoryError> = try await crudRepository
             .delete(XCTUnwrap(expectedMovies.last?.url))
-        await fulfillment(of: [secondExp], timeout: 5)
+        wait(for: [secondExp], timeout: 5)
     }
 }

--- a/Tests/CoreDataRepositoryTests/FetchRepositoryTests.swift
+++ b/Tests/CoreDataRepositoryTests/FetchRepositoryTests.swift
@@ -83,7 +83,7 @@ final class FetchRepositoryTests: CoreDataXCTestCase {
 
             })
             .store(in: &cancellables)
-        wait(for: [firstExp], timeout: 5)
+        await fulfillment(of: [firstExp], timeout: 5)
         let crudRepository = try CoreDataRepository(context: repositoryContext())
         _ = try await repositoryContext().perform { [self] in
             let url = try XCTUnwrap(expectedMovies.last?.url)
@@ -95,6 +95,6 @@ final class FetchRepositoryTests: CoreDataXCTestCase {
         }
         let _: Result<Void, CoreDataRepositoryError> = try await crudRepository
             .delete(XCTUnwrap(expectedMovies.last?.url))
-        wait(for: [secondExp], timeout: 5)
+        await fulfillment(of: [secondExp], timeout: 5)
     }
 }


### PR DESCRIPTION
- Enable strict concurrency for swift 5.8+
- Add Xcode 15/swift 5.9 test strategy
- Fix use of deprecated batch read API in tests