### PR TITLE
Add method for custom operations in context

### DIFF
--- a/Sources/CoreDataRepository/CoreDataRepository+CRUD.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+CRUD.swift
@@ -99,7 +99,7 @@ extension CoreDataRepository {
         let readContext = context.childContext()
         return AsyncStream { continuation in
             let provider: ReadSubscription<Model>
-            switch Self.getObjectId(fromUrl: url, context: readContext) {
+            switch readContext.objectId(from: url) {
             case let .success(objectId):
                 provider = ReadSubscription<Model>(
                     objectId: objectId,
@@ -126,7 +126,7 @@ extension CoreDataRepository {
         let readContext = context.childContext()
         return AsyncThrowingStream { continuation in
             let provider: ReadThrowingSubscription<Model>
-            switch Self.getObjectId(fromUrl: url, context: readContext) {
+            switch readContext.objectId(from: url) {
             case let .success(objectId):
                 provider = ReadThrowingSubscription<Model>(
                     objectId: objectId,
@@ -144,15 +144,5 @@ extension CoreDataRepository {
                 provider.cancel()
             }
         }
-    }
-
-    private static func getObjectId(
-        fromUrl url: URL,
-        context: NSManagedObjectContext
-    ) -> Result<NSManagedObjectID, CoreDataError> {
-        guard let objectId = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: url) else {
-            return Result.failure(.failedToGetObjectIdFromUrl(url))
-        }
-        return .success(objectId)
     }
 }

--- a/Sources/CoreDataRepository/CoreDataRepository+Custom.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+Custom.swift
@@ -1,0 +1,24 @@
+// CoreDataRepository+Custom.swift
+// CoreDataRepository
+//
+//
+// MIT License
+//
+// Copyright © 2024 Andrew Roan
+
+import CoreData
+import Foundation
+
+extension CoreDataRepository {
+    /// Escape hatch method for performing arbitrary operations inside a 'scratchpad' `NSManagedObjectContext` where
+    /// changes will be discarded if not saved.
+    public func custom<T>(
+        schedule: NSManagedObjectContext.ScheduledTaskType = .enqueued,
+        block: @escaping (
+            _ parentContext: NSManagedObjectContext,
+            _ scratchPadContext: NSManagedObjectContext
+        ) throws -> T
+    ) async -> Result<T, CoreDataError> {
+        await context.performInScratchPad(schedule: schedule) { [context] scratchPad in try block(context, scratchPad) }
+    }
+}

--- a/Sources/CoreDataRepository/CoreDataRepository+Custom.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+Custom.swift
@@ -12,6 +12,9 @@ import Foundation
 extension CoreDataRepository {
     /// Escape hatch method for performing arbitrary operations inside a 'scratchpad' `NSManagedObjectContext` where
     /// changes will be discarded if not saved.
+    ///
+    /// The caller is responsible for saving the contexts and cleaning up if needed.
+    /// All this  method provides is the contexts and mapping `Error` into ``CoreDataError``.
     public func custom<T>(
         schedule: NSManagedObjectContext.ScheduledTaskType = .enqueued,
         block: @escaping (

--- a/Sources/CoreDataRepository/NSManagedObject+Helpers.swift
+++ b/Sources/CoreDataRepository/NSManagedObject+Helpers.swift
@@ -1,4 +1,4 @@
-// NSManagedObject+CRUDHelpers.swift
+// NSManagedObject+Helpers.swift
 // CoreDataRepository
 //
 //
@@ -11,7 +11,7 @@ import Foundation
 
 extension NSManagedObject {
     /// Helper function to handle casting ``NSManagedObject`` to a sub-class.
-    func asManagedModel<T>() throws -> T where T: NSManagedObject {
+    public func asManagedModel<T>() throws -> T where T: NSManagedObject {
         guard let repoManaged = self as? T else {
             throw CoreDataError.fetchedObjectFailedToCastToExpectedType
         }

--- a/Sources/CoreDataRepository/NSManagedObjectContext+Helpers.swift
+++ b/Sources/CoreDataRepository/NSManagedObjectContext+Helpers.swift
@@ -1,4 +1,4 @@
-// NSManagedObjectContext+CRUDHelpers.swift
+// NSManagedObjectContext+Helpers.swift
 // CoreDataRepository
 //
 //
@@ -11,7 +11,7 @@ import Foundation
 
 extension NSManagedObjectContext {
     /// Helper function for getting the ``NSManagedObjectID`` from an ``URL``
-    func objectId(from url: URL) -> Result<NSManagedObjectID, CoreDataError> {
+    public func objectId(from url: URL) -> Result<NSManagedObjectID, CoreDataError> {
         guard let objectId = persistentStoreCoordinator?.managedObjectID(forURIRepresentation: url) else {
             return .failure(CoreDataError.failedToGetObjectIdFromUrl(url))
         }
@@ -19,7 +19,7 @@ extension NSManagedObjectContext {
     }
 
     /// Helper function for checking that a managed object is not deleted in the store
-    func notDeletedObject(for id: NSManagedObjectID) throws -> NSManagedObject {
+    public func notDeletedObject(for id: NSManagedObjectID) throws -> NSManagedObject {
         let object: NSManagedObject = try existingObject(with: id)
         guard !object.isDeleted else {
             throw CoreDataError.fetchedObjectIsFlaggedAsDeleted


### PR DESCRIPTION
As an 'escape hatch' from the rigid API in the form of a new method that allows performing arbitrary operations against a scratchpad `NSManagedObjectContext` would be really helpful.

I don't love the naming ('custom') but didn't have any better ideas.