### PR TITLE
Add inlinable notations to public API

### DIFF
--- a/Sources/CoreDataRepository/CoreDataBatchError.swift
+++ b/Sources/CoreDataRepository/CoreDataBatchError.swift
@@ -21,10 +21,12 @@ public struct CoreDataBatchError<T>: Error {
     /// The underlying error.
     public let error: CoreDataError
 
+    @inlinable
     public var localizedDescription: String {
         error.localizedDescription
     }
 
+    @inlinable
     public init(item: T, error: CoreDataError) {
         self.item = item
         self.error = error

--- a/Sources/CoreDataRepository/CoreDataError.swift
+++ b/Sources/CoreDataRepository/CoreDataError.swift
@@ -108,6 +108,7 @@ public enum CoreDataError: Error, Hashable, Sendable {
 extension CoreDataError: CustomNSError {
     public static let errorDomain: String = "CoreDataRepository"
 
+    @inlinable
     public var errorCode: Int {
         switch self {
         case .failedToGetObjectIdFromUrl:
@@ -133,6 +134,7 @@ extension CoreDataError: CustomNSError {
 
     public static let urlUserInfoKey: String = "ObjectIdUrl"
 
+    @inlinable
     public var errorUserInfo: [String: Any] {
         switch self {
         case let .failedToGetObjectIdFromUrl(url):

--- a/Sources/CoreDataRepository/CoreDataRepository+Aggregate.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+Aggregate.swift
@@ -15,6 +15,7 @@ extension CoreDataRepository {
     // MARK: Count
 
     /// Get the count or quantity of managed object instances that satisfy the predicate.
+    @inlinable
     public func count<Value: Numeric>(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
@@ -35,6 +36,7 @@ extension CoreDataRepository {
     }
 
     /// Subscribe to the count or quantity of managed object instances that satisfy the predicate.
+    @inlinable
     public func countSubscription<Value: Numeric>(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
@@ -55,6 +57,7 @@ extension CoreDataRepository {
     }
 
     /// Subscribe to the count or quantity of managed object instances that satisfy the predicate.
+    @inlinable
     public func countThrowingSubscription<Value: Numeric>(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
@@ -77,6 +80,7 @@ extension CoreDataRepository {
     // MARK: Sum
 
     /// Get the sum of a managed object's numeric property for all instances that satisfy the predicate.
+    @inlinable
     public func sum<Value: Numeric>(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
@@ -95,6 +99,7 @@ extension CoreDataRepository {
     }
 
     /// Subscribe to the sum of a managed object's numeric property for all instances that satisfy the predicate.
+    @inlinable
     public func sumSubscription<Value: Numeric>(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
@@ -120,6 +125,7 @@ extension CoreDataRepository {
     }
 
     /// Subscribe to the sum of a managed object's numeric property for all instances that satisfy the predicate.
+    @inlinable
     public func sumThrowingSubscription<Value: Numeric>(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
@@ -147,6 +153,7 @@ extension CoreDataRepository {
     // MARK: Average
 
     /// Get the average of a managed object's numeric property for all instances that satisfy the predicate.
+    @inlinable
     public func average<Value: Numeric>(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
@@ -165,6 +172,7 @@ extension CoreDataRepository {
     }
 
     /// Subscribe to the average of a managed object's numeric property for all instances that satisfy the predicate.
+    @inlinable
     public func averageSubscription<Value: Numeric>(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
@@ -190,6 +198,7 @@ extension CoreDataRepository {
     }
 
     /// Subscribe to the average of a managed object's numeric property for all instances that satisfy the predicate.
+    @inlinable
     public func averageThrowingSubscription<Value: Numeric>(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
@@ -217,6 +226,7 @@ extension CoreDataRepository {
     // MARK: Min
 
     /// Get the min or minimum of a managed object's numeric property for all instances that satisfy the predicate.
+    @inlinable
     public func min<Value: Numeric>(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
@@ -236,6 +246,7 @@ extension CoreDataRepository {
 
     /// Subscribe to the min or minimum of a managed object's numeric property for all instances that satisfy the
     /// predicate.
+    @inlinable
     public func minSubscription<Value: Numeric>(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
@@ -262,6 +273,7 @@ extension CoreDataRepository {
 
     /// Subscribe to the min or minimum of a managed object's numeric property for all instances that satisfy the
     /// predicate.
+    @inlinable
     public func minThrowingSubscription<Value: Numeric>(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
@@ -289,6 +301,7 @@ extension CoreDataRepository {
     // MARK: Max
 
     /// Get the max or maximum of a managed object's numeric property for all instances that satisfy the predicate.
+    @inlinable
     public func max<Value: Numeric>(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
@@ -308,6 +321,7 @@ extension CoreDataRepository {
 
     /// Subscribe to the max or maximum of a managed object's numeric property for all instances that satisfy the
     /// predicate.
+    @inlinable
     public func maxSubscription<Value: Numeric>(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
@@ -334,6 +348,7 @@ extension CoreDataRepository {
 
     /// Subscribe to the max or maximum of a managed object's numeric property for all instances that satisfy the
     /// predicate.
+    @inlinable
     public func maxThrowingSubscription<Value: Numeric>(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
@@ -360,6 +375,7 @@ extension CoreDataRepository {
 
     // MARK: Internals
 
+    @usableFromInline
     enum AggregateFunction: String {
         case count
         case sum
@@ -379,7 +395,8 @@ extension CoreDataRepository {
         return value
     }
 
-    private static func send<Value>(
+    @usableFromInline
+    static func send<Value>(
         function: AggregateFunction,
         context: NSManagedObjectContext,
         predicate: NSPredicate,

--- a/Sources/CoreDataRepository/CoreDataRepository+Batch.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+Batch.swift
@@ -29,6 +29,7 @@ extension CoreDataRepository {
     /// Create a batch of unmanaged models.
     ///
     /// This operation is non-atomic. Each instance may succeed or fail individually.
+    @inlinable
     public func create<Model: UnmanagedModel>(
         _ items: [Model],
         transactionAuthor: String? = nil
@@ -68,6 +69,7 @@ extension CoreDataRepository {
     }
 
     /// Create a batch of unmanaged models.
+    @inlinable
     public func createAtomically<Model: UnmanagedModel>(
         _ items: [Model],
         transactionAuthor: String? = nil
@@ -92,6 +94,7 @@ extension CoreDataRepository {
     /// Read a batch of unmanaged models.
     ///
     /// This operation is non-atomic. Each instance may succeed or fail individually.
+    @inlinable
     public func read<Model: UnmanagedModel>(
         urls: [URL],
         as _: Model.Type
@@ -130,6 +133,7 @@ extension CoreDataRepository {
     }
 
     /// Read a batch of unmanaged models.
+    @inlinable
     public func readAtomically<Model: UnmanagedModel>(
         urls: [URL],
         as _: Model.Type
@@ -163,6 +167,7 @@ extension CoreDataRepository {
     /// Update the store with a batch of unmanaged models.
     ///
     /// This operation is non-atomic. Each instance may succeed or fail individually.
+    @inlinable
     public func update<Model: UnmanagedModel>(
         _ items: [Model],
         transactionAuthor: String? = nil
@@ -205,6 +210,7 @@ extension CoreDataRepository {
     }
 
     /// Update the store with a batch of unmanaged models.
+    @inlinable
     public func updateAtomically<Model: UnmanagedModel>(
         _ items: [Model],
         transactionAuthor: String? = nil

--- a/Sources/CoreDataRepository/CoreDataRepository+Batch.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+Batch.swift
@@ -11,6 +11,7 @@ import Foundation
 
 extension CoreDataRepository {
     /// Execute a NSBatchInsertRequest against the store.
+    @inlinable
     public func insert(
         _ request: NSBatchInsertRequest,
         transactionAuthor: String? = nil
@@ -149,6 +150,7 @@ extension CoreDataRepository {
     }
 
     /// Execute a NSBatchUpdateRequest against the store.
+    @inlinable
     public func update(
         _ request: NSBatchUpdateRequest,
         transactionAuthor: String? = nil
@@ -238,6 +240,7 @@ extension CoreDataRepository {
     }
 
     /// Execute a NSBatchDeleteRequest against the store.
+    @inlinable
     public func delete(
         _ request: NSBatchDeleteRequest,
         transactionAuthor: String? = nil
@@ -256,6 +259,7 @@ extension CoreDataRepository {
     /// Delete from the store with a batch of unmanaged models.
     ///
     /// This operation is non-atomic. Each instance may succeed or fail individually.
+    @inlinable
     public func delete(
         urls: [URL],
         transactionAuthor: String? = nil
@@ -295,6 +299,7 @@ extension CoreDataRepository {
     }
 
     /// Delete from the store with a batch of unmanaged models.
+    @inlinable
     public func deleteAtomically(
         urls: [URL],
         transactionAuthor: String? = nil

--- a/Sources/CoreDataRepository/CoreDataRepository+CRUD.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+CRUD.swift
@@ -75,6 +75,7 @@ extension CoreDataRepository {
     }
 
     /// Delete an instance from the store.
+    @inlinable
     public func delete(
         _ url: URL,
         transactionAuthor: String? = nil

--- a/Sources/CoreDataRepository/CoreDataRepository+CRUD.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+CRUD.swift
@@ -11,6 +11,7 @@ import Foundation
 
 extension CoreDataRepository {
     /// Create an instance in the store.
+    @inlinable
     public func create<Model: UnmanagedModel>(
         _ item: Model,
         transactionAuthor: String? = nil
@@ -37,6 +38,7 @@ extension CoreDataRepository {
     }
 
     /// Read an instance from the store.
+    @inlinable
     public func read<Model: UnmanagedReadOnlyModel>(
         _ url: URL,
         of _: Model.Type
@@ -50,6 +52,7 @@ extension CoreDataRepository {
     }
 
     /// Update the store with an unmanaged model.
+    @inlinable
     public func update<Model: UnmanagedModel>(
         _ url: URL,
         with item: Model,
@@ -93,6 +96,7 @@ extension CoreDataRepository {
     }
 
     /// Subscribe to updates of an instance in the store.
+    @inlinable
     public func readSubscription<Model: UnmanagedReadOnlyModel>(_ url: URL, of _: Model.Type)
         -> AsyncStream<Result<Model, CoreDataError>>
     {
@@ -120,6 +124,7 @@ extension CoreDataRepository {
     }
 
     /// Subscribe to updates of an instance in the store.
+    @inlinable
     public func readThrowingSubscription<Model: UnmanagedReadOnlyModel>(_ url: URL, of _: Model.Type)
         -> AsyncThrowingStream<Model, Error>
     {
@@ -146,7 +151,8 @@ extension CoreDataRepository {
         }
     }
 
-    private static func getObjectId(
+    @usableFromInline
+    static func getObjectId(
         fromUrl url: URL,
         context: NSManagedObjectContext
     ) -> Result<NSManagedObjectID, CoreDataError> {

--- a/Sources/CoreDataRepository/CoreDataRepository+Custom.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+Custom.swift
@@ -15,6 +15,7 @@ extension CoreDataRepository {
     ///
     /// The caller is responsible for saving the contexts and cleaning up if needed.
     /// All this  method provides is the contexts and mapping `Error` into ``CoreDataError``.
+    @inlinable
     public func custom<T>(
         schedule: NSManagedObjectContext.ScheduledTaskType = .enqueued,
         block: @escaping (

--- a/Sources/CoreDataRepository/CoreDataRepository+Fetch.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+Fetch.swift
@@ -11,6 +11,7 @@ import Foundation
 
 extension CoreDataRepository {
     /// Fetch items from the store with a ``NSFetchRequest``.
+    @inlinable
     public func fetch<Model: UnmanagedReadOnlyModel>(
         _ request: NSFetchRequest<Model.ManagedModel>,
         as _: Model.Type
@@ -21,6 +22,7 @@ extension CoreDataRepository {
     }
 
     /// Fetch items from the store with a ``NSFetchRequest`` and receive updates as the store changes.
+    @inlinable
     public func fetchSubscription<Model: UnmanagedReadOnlyModel>(
         _ request: NSFetchRequest<Model.ManagedModel>,
         of _: Model.Type
@@ -39,6 +41,7 @@ extension CoreDataRepository {
     }
 
     /// Fetch items from the store with a ``NSFetchRequest`` and receive updates as the store changes.
+    @inlinable
     public func fetchThrowingSubscription<Model: UnmanagedReadOnlyModel>(
         _ request: NSFetchRequest<Model.ManagedModel>,
         of _: Model.Type
@@ -57,6 +60,7 @@ extension CoreDataRepository {
     }
 
     /// Fetch items from the store with a ``NSFetchRequest`` and transform the results.
+    @inlinable
     public func fetch<Managed, Output>(
         request: NSFetchRequest<Managed>,
         operation: @escaping (_ results: [Managed]) throws -> Output

--- a/Sources/CoreDataRepository/CoreDataRepository.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository.swift
@@ -29,6 +29,7 @@ public final class CoreDataRepository {
     /// to be performed in.
     public let context: NSManagedObjectContext
 
+    @inlinable
     public init(context: NSManagedObjectContext) {
         self.context = context
     }

--- a/Sources/CoreDataRepository/Internal/AggregateSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/AggregateSubscription.swift
@@ -10,7 +10,9 @@ import CoreData
 import Foundation
 
 /// Subscription provider that sends updates when an aggregate fetch request changes
+@usableFromInline
 final class AggregateSubscription<Value>: Subscription<Value, NSDictionary, NSManagedObject> where Value: Numeric {
+    @usableFromInline
     override func fetch() {
         frc.managedObjectContext.perform { [weak self, frc, request] in
             guard frc.fetchedObjects != nil else {
@@ -37,6 +39,7 @@ final class AggregateSubscription<Value>: Subscription<Value, NSDictionary, NSMa
         }
     }
 
+    @usableFromInline
     convenience init(
         function: CoreDataRepository.AggregateFunction,
         context: NSManagedObjectContext,

--- a/Sources/CoreDataRepository/Internal/AggregateThrowingSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/AggregateThrowingSubscription.swift
@@ -10,9 +10,11 @@ import CoreData
 import Foundation
 
 /// Subscription provider that sends updates when an aggregate fetch request changes
+@usableFromInline
 final class AggregateThrowingSubscription<Value>: ThrowingSubscription<Value, NSDictionary, NSManagedObject>
     where Value: Numeric
 {
+    @usableFromInline
     override func fetch() {
         frc.managedObjectContext.perform { [weak self, frc, request] in
             guard frc.fetchedObjects != nil else {
@@ -39,6 +41,7 @@ final class AggregateThrowingSubscription<Value>: ThrowingSubscription<Value, NS
         }
     }
 
+    @usableFromInline
     convenience init(
         function: CoreDataRepository.AggregateFunction,
         context: NSManagedObjectContext,

--- a/Sources/CoreDataRepository/Internal/BaseSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/BaseSubscription.swift
@@ -10,6 +10,7 @@ import CoreData
 import Foundation
 
 /// Base class for other subscriptions.
+@usableFromInline
 class BaseSubscription<
     Output,
     RequestResult: NSFetchRequestResult,
@@ -18,6 +19,7 @@ class BaseSubscription<
     let request: NSFetchRequest<RequestResult>
     let frc: NSFetchedResultsController<ControllerResult>
 
+    @usableFromInline
     init(
         fetchRequest: NSFetchRequest<RequestResult>,
         fetchResultControllerRequest: NSFetchRequest<ControllerResult>,
@@ -35,14 +37,17 @@ class BaseSubscription<
         start()
     }
 
+    @usableFromInline
     func fetch() {
         fatalError("\(Self.self).\(#function) is not implemented.")
     }
 
+    @usableFromInline
     func controllerDidChangeContent(_: NSFetchedResultsController<NSFetchRequestResult>) {
         fetch()
     }
 
+    @usableFromInline
     func start() {
         do {
             try frc.performFetch()
@@ -53,18 +58,22 @@ class BaseSubscription<
         }
     }
 
+    @usableFromInline
     func manualFetch() {
         fetch()
     }
 
+    @usableFromInline
     func cancel() {
         fatalError("\(Self.self).\(#function) is not implemented.")
     }
 
+    @usableFromInline
     func fail(_: CoreDataError) {
         fatalError("\(Self.self).\(#function) is not implemented.")
     }
 
+    @usableFromInline
     func send(_: Output) {
         fatalError("\(Self.self).\(#function) is not implemented.")
     }

--- a/Sources/CoreDataRepository/Internal/CountSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/CountSubscription.swift
@@ -10,7 +10,9 @@ import CoreData
 import Foundation
 
 /// Subscription provider that sends updates when a count fetch request changes
+@usableFromInline
 final class CountSubscription<Value>: Subscription<Value, NSDictionary, NSManagedObject> where Value: Numeric {
+    @usableFromInline
     override func fetch() {
         frc.managedObjectContext.perform { [weak self, frc] in
             if (frc.fetchedObjects ?? []).isEmpty {
@@ -27,6 +29,7 @@ final class CountSubscription<Value>: Subscription<Value, NSDictionary, NSManage
         }
     }
 
+    @usableFromInline
     convenience init(
         context: NSManagedObjectContext,
         predicate: NSPredicate,

--- a/Sources/CoreDataRepository/Internal/CountThrowingSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/CountThrowingSubscription.swift
@@ -10,9 +10,11 @@ import CoreData
 import Foundation
 
 /// Subscription provider that sends updates when a count fetch request changes
+@usableFromInline
 final class CountThrowingSubscription<Value>: ThrowingSubscription<Value, NSDictionary, NSManagedObject>
     where Value: Numeric
 {
+    @usableFromInline
     override func fetch() {
         frc.managedObjectContext.perform { [weak self, frc] in
             if (frc.fetchedObjects ?? []).isEmpty {
@@ -29,6 +31,7 @@ final class CountThrowingSubscription<Value>: ThrowingSubscription<Value, NSDict
         }
     }
 
+    @usableFromInline
     convenience init(
         context: NSManagedObjectContext,
         predicate: NSPredicate,

--- a/Sources/CoreDataRepository/Internal/FetchSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/FetchSubscription.swift
@@ -10,11 +10,13 @@ import CoreData
 import Foundation
 
 /// Subscription provider that sends updates when a fetch request changes
+@usableFromInline
 final class FetchSubscription<Model: UnmanagedReadOnlyModel>: Subscription<
     [Model],
     Model.ManagedModel,
     Model.ManagedModel
 > {
+    @usableFromInline
     override func fetch() {
         frc.managedObjectContext.perform { [weak self, frc, request] in
             guard frc.fetchedObjects != nil else {

--- a/Sources/CoreDataRepository/Internal/FetchThrowingSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/FetchThrowingSubscription.swift
@@ -10,11 +10,13 @@ import CoreData
 import Foundation
 
 /// Subscription provider that sends updates when a fetch request changes
+@usableFromInline
 final class FetchThrowingSubscription<Model: UnmanagedReadOnlyModel>: ThrowingSubscription<
     [Model],
     Model.ManagedModel,
     Model.ManagedModel
 > {
+    @usableFromInline
     override func fetch() {
         frc.managedObjectContext.perform { [weak self, frc, request] in
             guard frc.fetchedObjects != nil else {

--- a/Sources/CoreDataRepository/Internal/NSFetchRequest+AggregateHelpers.swift
+++ b/Sources/CoreDataRepository/Internal/NSFetchRequest+AggregateHelpers.swift
@@ -11,6 +11,7 @@ import Foundation
 
 extension NSFetchRequest<NSDictionary> {
     /// Helper function for building an aggregate fetch request
+    @usableFromInline
     static func request(
         function: CoreDataRepository.AggregateFunction,
         predicate: NSPredicate,
@@ -39,6 +40,7 @@ extension NSFetchRequest<NSDictionary> {
     }
 
     /// Helper function for building a count fetch request
+    @usableFromInline
     static func countRequest(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription

--- a/Sources/CoreDataRepository/Internal/NSManagedObject+CRUDHelpers.swift
+++ b/Sources/CoreDataRepository/Internal/NSManagedObject+CRUDHelpers.swift
@@ -11,6 +11,7 @@ import Foundation
 
 extension NSManagedObject {
     /// Helper function to handle casting ``NSManagedObject`` to a sub-class.
+    @usableFromInline
     func asManagedModel<T>() throws -> T where T: NSManagedObject {
         guard let repoManaged = self as? T else {
             throw CoreDataError.fetchedObjectFailedToCastToExpectedType

--- a/Sources/CoreDataRepository/Internal/NSManagedObjectContext+CRUDHelpers.swift
+++ b/Sources/CoreDataRepository/Internal/NSManagedObjectContext+CRUDHelpers.swift
@@ -11,6 +11,7 @@ import Foundation
 
 extension NSManagedObjectContext {
     /// Helper function for getting the ``NSManagedObjectID`` from an ``URL``
+    @usableFromInline
     func objectId(from url: URL) -> Result<NSManagedObjectID, CoreDataError> {
         guard let objectId = persistentStoreCoordinator?.managedObjectID(forURIRepresentation: url) else {
             return .failure(CoreDataError.failedToGetObjectIdFromUrl(url))
@@ -19,6 +20,7 @@ extension NSManagedObjectContext {
     }
 
     /// Helper function for checking that a managed object is not deleted in the store
+    @usableFromInline
     func notDeletedObject(for id: NSManagedObjectID) throws -> NSManagedObject {
         let object: NSManagedObject = try existingObject(with: id)
         guard !object.isDeleted else {

--- a/Sources/CoreDataRepository/Internal/NSManagedObjectContext+Child.swift
+++ b/Sources/CoreDataRepository/Internal/NSManagedObjectContext+Child.swift
@@ -11,6 +11,7 @@ import Foundation
 
 extension NSManagedObjectContext {
     /// Helper function for error mapping a throwing operation in a temporary context
+    @usableFromInline
     func performInChild<Output>(
         schedule: NSManagedObjectContext.ScheduledTaskType = .immediate,
         _ block: @escaping (NSManagedObjectContext) throws -> Output
@@ -30,6 +31,7 @@ extension NSManagedObjectContext {
     }
 
     /// Helper function for getting a temporary context
+    @usableFromInline
     func childContext() -> NSManagedObjectContext {
         let child = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         child.automaticallyMergesChangesFromParent = true

--- a/Sources/CoreDataRepository/Internal/NSManagedObjectContext+Scratchpad.swift
+++ b/Sources/CoreDataRepository/Internal/NSManagedObjectContext+Scratchpad.swift
@@ -10,6 +10,7 @@ import CoreData
 import Foundation
 
 extension NSManagedObjectContext {
+    @usableFromInline
     func performInScratchPad<Output>(
         schedule: NSManagedObjectContext.ScheduledTaskType = .immediate,
         _ block: @escaping (NSManagedObjectContext) throws -> Output

--- a/Sources/CoreDataRepository/Internal/ReadSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/ReadSubscription.swift
@@ -11,12 +11,14 @@ import CoreData
 import Foundation
 
 /// Subscription provider that sends updates when a single ``NSManagedObject`` changes
+@usableFromInline
 final class ReadSubscription<Model: UnmanagedReadOnlyModel> {
     private let objectId: NSManagedObjectID
     private let context: NSManagedObjectContext
     private var cancellables: Set<AnyCancellable>
     private let continuation: AsyncStream<Result<Model, CoreDataError>>.Continuation
 
+    @usableFromInline
     func manualFetch() {
         context.perform { [weak self, context, objectId] in
             guard let object = context.object(with: objectId) as? Model.ManagedModel else {
@@ -31,11 +33,13 @@ final class ReadSubscription<Model: UnmanagedReadOnlyModel> {
         }
     }
 
+    @usableFromInline
     func cancel() {
         continuation.finish()
         cancellables.forEach { $0.cancel() }
     }
 
+    @usableFromInline
     func start() {
         context.perform { [weak self, context, objectId] in
             guard let object = context.object(with: objectId) as? Model.ManagedModel else {
@@ -53,6 +57,7 @@ final class ReadSubscription<Model: UnmanagedReadOnlyModel> {
         }
     }
 
+    @usableFromInline
     init(
         objectId: NSManagedObjectID,
         context: NSManagedObjectContext,

--- a/Sources/CoreDataRepository/Internal/ReadThrowingSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/ReadThrowingSubscription.swift
@@ -10,12 +10,14 @@ import Combine
 import CoreData
 import Foundation
 
+@usableFromInline
 final class ReadThrowingSubscription<Model: UnmanagedReadOnlyModel> {
     private let objectId: NSManagedObjectID
     private let context: NSManagedObjectContext
     private var cancellables: Set<AnyCancellable>
     private let continuation: AsyncThrowingStream<Model, Error>.Continuation
 
+    @usableFromInline
     func manualFetch() {
         context.perform { [weak self, context, objectId] in
             guard let object = context.object(with: objectId) as? Model.ManagedModel else {
@@ -30,11 +32,13 @@ final class ReadThrowingSubscription<Model: UnmanagedReadOnlyModel> {
         }
     }
 
+    @usableFromInline
     func cancel() {
         continuation.finish()
         cancellables.forEach { $0.cancel() }
     }
 
+    @usableFromInline
     func start() {
         context.perform { [weak self, context, objectId] in
             guard let object = context.object(with: objectId) as? Model.ManagedModel else {
@@ -52,6 +56,7 @@ final class ReadThrowingSubscription<Model: UnmanagedReadOnlyModel> {
         }
     }
 
+    @usableFromInline
     init(
         objectId: NSManagedObjectID,
         context: NSManagedObjectContext,

--- a/Sources/CoreDataRepository/Internal/Subscription.swift
+++ b/Sources/CoreDataRepository/Internal/Subscription.swift
@@ -10,6 +10,7 @@ import CoreData
 import Foundation
 
 /// Base class for other subscriptions.
+@usableFromInline
 class Subscription<
     Output,
     RequestResult: NSFetchRequestResult,
@@ -17,6 +18,7 @@ class Subscription<
 >: BaseSubscription<Output, RequestResult, ControllerResult> {
     let continuation: AsyncStream<Result<Output, CoreDataError>>.Continuation
 
+    @usableFromInline
     init(
         fetchRequest: NSFetchRequest<RequestResult>,
         fetchResultControllerRequest: NSFetchRequest<ControllerResult>,
@@ -31,14 +33,17 @@ class Subscription<
         )
     }
 
+    @usableFromInline
     override func cancel() {
         continuation.finish()
     }
 
+    @usableFromInline
     override final func fail(_ error: CoreDataError) {
         continuation.yield(.failure(error))
     }
 
+    @usableFromInline
     override final func send(_ value: Output) {
         continuation.yield(.success(value))
     }
@@ -47,6 +52,7 @@ class Subscription<
 // MARK: where RequestResult == ControllerResult
 
 extension Subscription where RequestResult == ControllerResult {
+    @usableFromInline
     convenience init(
         request: NSFetchRequest<RequestResult>,
         context: NSManagedObjectContext,
@@ -64,6 +70,7 @@ extension Subscription where RequestResult == ControllerResult {
 // MARK: where RequestResult == NSDictionary, ControllerResult == NSManagedObject
 
 extension Subscription where RequestResult == NSDictionary, ControllerResult == NSManagedObject {
+    @usableFromInline
     convenience init(
         request: NSFetchRequest<NSDictionary>,
         context: NSManagedObjectContext,

--- a/Sources/CoreDataRepository/Internal/ThrowingSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/ThrowingSubscription.swift
@@ -10,6 +10,7 @@ import CoreData
 import Foundation
 
 /// Base class for other subscriptions.
+@usableFromInline
 class ThrowingSubscription<
     Output,
     RequestResult: NSFetchRequestResult,
@@ -17,6 +18,7 @@ class ThrowingSubscription<
 >: BaseSubscription<Output, RequestResult, ControllerResult> {
     private let continuation: AsyncThrowingStream<Output, Error>.Continuation
 
+    @usableFromInline
     init(
         fetchRequest: NSFetchRequest<RequestResult>,
         fetchResultControllerRequest: NSFetchRequest<ControllerResult>,
@@ -31,14 +33,17 @@ class ThrowingSubscription<
         )
     }
 
+    @usableFromInline
     override func cancel() {
         continuation.finish()
     }
 
+    @usableFromInline
     override final func fail(_ error: CoreDataError) {
         continuation.yield(with: .failure(error))
     }
 
+    @usableFromInline
     override final func send(_ value: Output) {
         continuation.yield(with: .success(value))
     }
@@ -47,6 +52,7 @@ class ThrowingSubscription<
 // MARK: where RequestResult == ControllerResult
 
 extension ThrowingSubscription where RequestResult == ControllerResult {
+    @usableFromInline
     convenience init(
         request: NSFetchRequest<RequestResult>,
         context: NSManagedObjectContext,
@@ -64,6 +70,7 @@ extension ThrowingSubscription where RequestResult == ControllerResult {
 // MARK: where RequestResult == NSDictionary, ControllerResult == NSManagedObject
 
 extension ThrowingSubscription where RequestResult == NSDictionary, ControllerResult == NSManagedObject {
+    @usableFromInline
     convenience init(
         request: NSFetchRequest<NSDictionary>,
         context: NSManagedObjectContext,

--- a/Sources/CoreDataRepository/NSManagedObject+Helpers.swift
+++ b/Sources/CoreDataRepository/NSManagedObject+Helpers.swift
@@ -11,7 +11,7 @@ import Foundation
 
 extension NSManagedObject {
     /// Helper function to handle casting ``NSManagedObject`` to a sub-class.
-	@inlinable
+    @inlinable
     public func asManagedModel<T>() throws -> T where T: NSManagedObject {
         guard let repoManaged = self as? T else {
             throw CoreDataError.fetchedObjectFailedToCastToExpectedType

--- a/Sources/CoreDataRepository/NSManagedObjectContext+Helpers.swift
+++ b/Sources/CoreDataRepository/NSManagedObjectContext+Helpers.swift
@@ -11,7 +11,7 @@ import Foundation
 
 extension NSManagedObjectContext {
     /// Helper function for getting the ``NSManagedObjectID`` from an ``URL``
-	@inlinable
+    @inlinable
     public func objectId(from url: URL) -> Result<NSManagedObjectID, CoreDataError> {
         guard let objectId = persistentStoreCoordinator?.managedObjectID(forURIRepresentation: url) else {
             return .failure(CoreDataError.failedToGetObjectIdFromUrl(url))
@@ -20,7 +20,7 @@ extension NSManagedObjectContext {
     }
 
     /// Helper function for checking that a managed object is not deleted in the store
-	@inlinable
+    @inlinable
     public func notDeletedObject(for id: NSManagedObjectID) throws -> NSManagedObject {
         let object: NSManagedObject = try existingObject(with: id)
         guard !object.isDeleted else {

--- a/Sources/CoreDataRepository/UnmanagedReadOnlyModel.swift
+++ b/Sources/CoreDataRepository/UnmanagedReadOnlyModel.swift
@@ -81,6 +81,7 @@ public protocol UnmanagedReadOnlyModel: Equatable {
 }
 
 extension UnmanagedReadOnlyModel {
+    @inlinable
     public static func managedFetchRequest() -> NSFetchRequest<ManagedModel> {
         NSFetchRequest<ManagedModel>(
             entityName: ManagedModel.entity().name ?? ManagedModel.entity()


### PR DESCRIPTION
Something I've been aware of but not considered much is that Swift offers notations that control public module interface and  may allow better optimizations when used from outside the module.

At a minimum, it seems to be good to mark public methods and computed properties as `@inlinable`. A declaration that is marked as `@inlinable` requires that `internal` declarations called within it be marked as `@usableFromInline`.

I haven't exhaustively covered each possible declaration but the primary public API should all be covered now.

https://github.com/apple/swift-evolution/blob/b8731d0d086c5cc0a08457a917c1d88ba3d202d2/proposals/0193-cross-module-inlining-and-specialization.md
https://forums.swift.org/t/when-should-both-inlinable-and-inline-always-be-used/37375