### PR TITLE
Disable internal imports by default

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,6 @@ extension [SwiftSetting] {
         .enableUpcomingFeature("DisableOutwardActorInference"),
         .enableUpcomingFeature("ForwardTrailingClosures"),
         .enableUpcomingFeature("ImportObjcForwardDeclarations"),
-        .enableUpcomingFeature("InternalImportsByDefault"),
-        .enableUpcomingFeature("StrictConcurrency"),
+        .enableExperimentalFeature("StrictConcurrency"),
     ]
 }


### PR DESCRIPTION
Fix manifest for Xcode 16/Swift 6