### PR TITLE
Enable different request for frc in subscriptions

### DIFF
--- a/Sources/CoreDataRepository/CoreDataRepository+Aggregate.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+Aggregate.swift
@@ -90,6 +90,38 @@ extension CoreDataRepository {
     }
 
     /// Subscribe to the average of a managed object's numeric property for all instances that satisfy the predicate.
+    ///
+    /// This endpoint allows separate fetch requests for fetching and change tracking. There are times where CoreData
+    /// will not recognize changes with a specific predicate. The fix, is to use a simplified predicate for change
+    /// tracking and the full predicate for fetching.
+    @inlinable
+    public func averageSubscription<Value: Numeric & Sendable>(
+        predicate: NSPredicate,
+        changeTrackingRequest: NSFetchRequest<NSManagedObject>,
+        entityDesc: NSEntityDescription,
+        attributeDesc: NSAttributeDescription,
+        groupBy: NSAttributeDescription? = nil,
+        as _: Value.Type
+    ) -> AsyncStream<Result<Value, CoreDataError>> {
+        AsyncStream { continuation in
+            let subscription = AggregateSubscription(
+                function: .average,
+                context: context.childContext(),
+                predicate: predicate,
+                changeTrackingRequest: changeTrackingRequest,
+                entityDesc: entityDesc,
+                attributeDesc: attributeDesc,
+                groupBy: groupBy,
+                continuation: continuation
+            )
+            continuation.onTermination = { _ in
+                subscription.cancel()
+            }
+            subscription.manualFetch()
+        }
+    }
+
+    /// Subscribe to the average of a managed object's numeric property for all instances that satisfy the predicate.
     @inlinable
     public func averageThrowingSubscription<Value: Numeric & Sendable>(
         predicate: NSPredicate,
@@ -103,6 +135,38 @@ extension CoreDataRepository {
                 function: .average,
                 context: context.childContext(),
                 predicate: predicate,
+                entityDesc: entityDesc,
+                attributeDesc: attributeDesc,
+                groupBy: groupBy,
+                continuation: continuation
+            )
+            continuation.onTermination = { _ in
+                subscription.cancel()
+            }
+            subscription.manualFetch()
+        }
+    }
+
+    /// Subscribe to the average of a managed object's numeric property for all instances that satisfy the predicate.
+    ///
+    /// This endpoint allows separate fetch requests for fetching and change tracking. There are times where CoreData
+    /// will not recognize changes with a specific predicate. The fix, is to use a simplified predicate for change
+    /// tracking and the full predicate for fetching.
+    @inlinable
+    public func averageThrowingSubscription<Value: Numeric & Sendable>(
+        predicate: NSPredicate,
+        changeTrackingRequest: NSFetchRequest<NSManagedObject>,
+        entityDesc: NSEntityDescription,
+        attributeDesc: NSAttributeDescription,
+        groupBy: NSAttributeDescription? = nil,
+        as _: Value.Type
+    ) -> AsyncThrowingStream<Value, Error> {
+        AsyncThrowingStream { continuation in
+            let subscription = AggregateThrowingSubscription(
+                function: .average,
+                context: context.childContext(),
+                predicate: predicate,
+                changeTrackingRequest: changeTrackingRequest,
                 entityDesc: entityDesc,
                 attributeDesc: attributeDesc,
                 groupBy: groupBy,
@@ -160,6 +224,33 @@ extension CoreDataRepository {
     }
 
     /// Subscribe to the count or quantity of managed object instances that satisfy the predicate.
+    ///
+    /// This endpoint allows separate fetch requests for fetching and change tracking. There are times where CoreData
+    /// will not recognize changes with a specific predicate. The fix, is to use a simplified predicate for change
+    /// tracking and the full predicate for fetching.
+    @inlinable
+    public func countSubscription<Value: Numeric & Sendable>(
+        predicate: NSPredicate,
+        changeTrackingRequest: NSFetchRequest<NSManagedObject>,
+        entityDesc: NSEntityDescription,
+        as _: Value.Type
+    ) -> AsyncStream<Result<Value, CoreDataError>> {
+        AsyncStream { continuation in
+            let subscription = CountSubscription(
+                context: context.childContext(),
+                predicate: predicate,
+                changeTrackingRequest: changeTrackingRequest,
+                entityDesc: entityDesc,
+                continuation: continuation
+            )
+            continuation.onTermination = { _ in
+                subscription.cancel()
+            }
+            subscription.manualFetch()
+        }
+    }
+
+    /// Subscribe to the count or quantity of managed object instances that satisfy the predicate.
     @inlinable
     public func countThrowingSubscription<Value: Numeric & Sendable>(
         predicate: NSPredicate,
@@ -170,6 +261,33 @@ extension CoreDataRepository {
             let subscription = CountThrowingSubscription(
                 context: context.childContext(),
                 predicate: predicate,
+                entityDesc: entityDesc,
+                continuation: continuation
+            )
+            continuation.onTermination = { _ in
+                subscription.cancel()
+            }
+            subscription.manualFetch()
+        }
+    }
+
+    /// Subscribe to the count or quantity of managed object instances that satisfy the predicate.
+    ///
+    /// This endpoint allows separate fetch requests for fetching and change tracking. There are times where CoreData
+    /// will not recognize changes with a specific predicate. The fix, is to use a simplified predicate for change
+    /// tracking and the full predicate for fetching.
+    @inlinable
+    public func countThrowingSubscription<Value: Numeric & Sendable>(
+        predicate: NSPredicate,
+        changeTrackingRequest: NSFetchRequest<NSManagedObject>,
+        entityDesc: NSEntityDescription,
+        as _: Value.Type
+    ) -> AsyncThrowingStream<Value, Error> {
+        AsyncThrowingStream { continuation in
+            let subscription = CountThrowingSubscription(
+                context: context.childContext(),
+                predicate: predicate,
+                changeTrackingRequest: changeTrackingRequest,
                 entityDesc: entityDesc,
                 continuation: continuation
             )
@@ -230,6 +348,39 @@ extension CoreDataRepository {
 
     /// Subscribe to the max or maximum of a managed object's numeric property for all instances that satisfy the
     /// predicate.
+    ///
+    /// This endpoint allows separate fetch requests for fetching and change tracking. There are times where CoreData
+    /// will not recognize changes with a specific predicate. The fix, is to use a simplified predicate for change
+    /// tracking and the full predicate for fetching.
+    @inlinable
+    public func maxSubscription<Value: Numeric & Sendable>(
+        predicate: NSPredicate,
+        changeTrackingRequest: NSFetchRequest<NSManagedObject>,
+        entityDesc: NSEntityDescription,
+        attributeDesc: NSAttributeDescription,
+        groupBy: NSAttributeDescription? = nil,
+        as _: Value.Type
+    ) -> AsyncStream<Result<Value, CoreDataError>> {
+        AsyncStream { continuation in
+            let subscription = AggregateSubscription(
+                function: .max,
+                context: context.childContext(),
+                predicate: predicate,
+                changeTrackingRequest: changeTrackingRequest,
+                entityDesc: entityDesc,
+                attributeDesc: attributeDesc,
+                groupBy: groupBy,
+                continuation: continuation
+            )
+            continuation.onTermination = { _ in
+                subscription.cancel()
+            }
+            subscription.manualFetch()
+        }
+    }
+
+    /// Subscribe to the max or maximum of a managed object's numeric property for all instances that satisfy the
+    /// predicate.
     @inlinable
     public func maxThrowingSubscription<Value: Numeric & Sendable>(
         predicate: NSPredicate,
@@ -243,6 +394,39 @@ extension CoreDataRepository {
                 function: .max,
                 context: context.childContext(),
                 predicate: predicate,
+                entityDesc: entityDesc,
+                attributeDesc: attributeDesc,
+                groupBy: groupBy,
+                continuation: continuation
+            )
+            continuation.onTermination = { _ in
+                subscription.cancel()
+            }
+            subscription.manualFetch()
+        }
+    }
+
+    /// Subscribe to the max or maximum of a managed object's numeric property for all instances that satisfy the
+    /// predicate.
+    ///
+    /// This endpoint allows separate fetch requests for fetching and change tracking. There are times where CoreData
+    /// will not recognize changes with a specific predicate. The fix, is to use a simplified predicate for change
+    /// tracking and the full predicate for fetching.
+    @inlinable
+    public func maxThrowingSubscription<Value: Numeric & Sendable>(
+        predicate: NSPredicate,
+        changeTrackingRequest: NSFetchRequest<NSManagedObject>,
+        entityDesc: NSEntityDescription,
+        attributeDesc: NSAttributeDescription,
+        groupBy: NSAttributeDescription? = nil,
+        as _: Value.Type
+    ) -> AsyncThrowingStream<Value, Error> {
+        AsyncThrowingStream { continuation in
+            let subscription = AggregateThrowingSubscription(
+                function: .max,
+                context: context.childContext(),
+                predicate: predicate,
+                changeTrackingRequest: changeTrackingRequest,
                 entityDesc: entityDesc,
                 attributeDesc: attributeDesc,
                 groupBy: groupBy,
@@ -305,6 +489,39 @@ extension CoreDataRepository {
 
     /// Subscribe to the min or minimum of a managed object's numeric property for all instances that satisfy the
     /// predicate.
+    ///
+    /// This endpoint allows separate fetch requests for fetching and change tracking. There are times where CoreData
+    /// will not recognize changes with a specific predicate. The fix, is to use a simplified predicate for change
+    /// tracking and the full predicate for fetching.
+    @inlinable
+    public func minSubscription<Value: Numeric & Sendable>(
+        predicate: NSPredicate,
+        changeTrackingRequest: NSFetchRequest<NSManagedObject>,
+        entityDesc: NSEntityDescription,
+        attributeDesc: NSAttributeDescription,
+        groupBy: NSAttributeDescription? = nil,
+        as _: Value.Type
+    ) -> AsyncStream<Result<Value, CoreDataError>> {
+        AsyncStream { continuation in
+            let subscription = AggregateSubscription(
+                function: .min,
+                context: context.childContext(),
+                predicate: predicate,
+                changeTrackingRequest: changeTrackingRequest,
+                entityDesc: entityDesc,
+                attributeDesc: attributeDesc,
+                groupBy: groupBy,
+                continuation: continuation
+            )
+            continuation.onTermination = { _ in
+                subscription.cancel()
+            }
+            subscription.manualFetch()
+        }
+    }
+
+    /// Subscribe to the min or minimum of a managed object's numeric property for all instances that satisfy the
+    /// predicate.
     @inlinable
     public func minThrowingSubscription<Value: Numeric & Sendable>(
         predicate: NSPredicate,
@@ -318,6 +535,39 @@ extension CoreDataRepository {
                 function: .min,
                 context: context.childContext(),
                 predicate: predicate,
+                entityDesc: entityDesc,
+                attributeDesc: attributeDesc,
+                groupBy: groupBy,
+                continuation: continuation
+            )
+            continuation.onTermination = { _ in
+                subscription.cancel()
+            }
+            subscription.manualFetch()
+        }
+    }
+
+    /// Subscribe to the min or minimum of a managed object's numeric property for all instances that satisfy the
+    /// predicate.
+    ///
+    /// This endpoint allows separate fetch requests for fetching and change tracking. There are times where CoreData
+    /// will not recognize changes with a specific predicate. The fix, is to use a simplified predicate for change
+    /// tracking and the full predicate for fetching.
+    @inlinable
+    public func minThrowingSubscription<Value: Numeric & Sendable>(
+        predicate: NSPredicate,
+        changeTrackingRequest: NSFetchRequest<NSManagedObject>,
+        entityDesc: NSEntityDescription,
+        attributeDesc: NSAttributeDescription,
+        groupBy: NSAttributeDescription? = nil,
+        as _: Value.Type
+    ) -> AsyncThrowingStream<Value, Error> {
+        AsyncThrowingStream { continuation in
+            let subscription = AggregateThrowingSubscription(
+                function: .min,
+                context: context.childContext(),
+                predicate: predicate,
+                changeTrackingRequest: changeTrackingRequest,
                 entityDesc: entityDesc,
                 attributeDesc: attributeDesc,
                 groupBy: groupBy,
@@ -378,6 +628,38 @@ extension CoreDataRepository {
     }
 
     /// Subscribe to the sum of a managed object's numeric property for all instances that satisfy the predicate.
+    ///
+    /// This endpoint allows separate fetch requests for fetching and change tracking. There are times where CoreData
+    /// will not recognize changes with a specific predicate. The fix, is to use a simplified predicate for change
+    /// tracking and the full predicate for fetching.
+    @inlinable
+    public func sumSubscription<Value: Numeric & Sendable>(
+        predicate: NSPredicate,
+        changeTrackingRequest: NSFetchRequest<NSManagedObject>,
+        entityDesc: NSEntityDescription,
+        attributeDesc: NSAttributeDescription,
+        groupBy: NSAttributeDescription? = nil,
+        as _: Value.Type
+    ) -> AsyncStream<Result<Value, CoreDataError>> {
+        AsyncStream { continuation in
+            let subscription = AggregateSubscription(
+                function: .sum,
+                context: context.childContext(),
+                predicate: predicate,
+                changeTrackingRequest: changeTrackingRequest,
+                entityDesc: entityDesc,
+                attributeDesc: attributeDesc,
+                groupBy: groupBy,
+                continuation: continuation
+            )
+            continuation.onTermination = { _ in
+                subscription.cancel()
+            }
+            subscription.manualFetch()
+        }
+    }
+
+    /// Subscribe to the sum of a managed object's numeric property for all instances that satisfy the predicate.
     @inlinable
     public func sumThrowingSubscription<Value: Numeric & Sendable>(
         predicate: NSPredicate,
@@ -391,6 +673,38 @@ extension CoreDataRepository {
                 function: .sum,
                 context: context.childContext(),
                 predicate: predicate,
+                entityDesc: entityDesc,
+                attributeDesc: attributeDesc,
+                groupBy: groupBy,
+                continuation: continuation
+            )
+            continuation.onTermination = { _ in
+                subscription.cancel()
+            }
+            subscription.manualFetch()
+        }
+    }
+
+    /// Subscribe to the sum of a managed object's numeric property for all instances that satisfy the predicate.
+    ///
+    /// This endpoint allows separate fetch requests for fetching and change tracking. There are times where CoreData
+    /// will not recognize changes with a specific predicate. The fix, is to use a simplified predicate for change
+    /// tracking and the full predicate for fetching.
+    @inlinable
+    public func sumThrowingSubscription<Value: Numeric & Sendable>(
+        predicate: NSPredicate,
+        changeTrackingRequest: NSFetchRequest<NSManagedObject>,
+        entityDesc: NSEntityDescription,
+        attributeDesc: NSAttributeDescription,
+        groupBy: NSAttributeDescription? = nil,
+        as _: Value.Type
+    ) -> AsyncThrowingStream<Value, Error> {
+        AsyncThrowingStream { continuation in
+            let subscription = AggregateThrowingSubscription(
+                function: .sum,
+                context: context.childContext(),
+                predicate: predicate,
+                changeTrackingRequest: changeTrackingRequest,
                 entityDesc: entityDesc,
                 attributeDesc: attributeDesc,
                 groupBy: groupBy,

--- a/Sources/CoreDataRepository/CoreDataRepository+Fetch.swift
+++ b/Sources/CoreDataRepository/CoreDataRepository+Fetch.swift
@@ -40,6 +40,31 @@ extension CoreDataRepository {
     }
 
     /// Fetch items from the store with a ``NSFetchRequest`` and receive updates as the store changes.
+    ///
+    /// This endpoint allows separate fetch requests for fetching and change tracking. There are times where CoreData
+    /// will not recognize changes with a specific predicate. The fix, is to use a simplified predicate for change
+    /// tracking and the full predicate for fetching.
+    @inlinable
+    public func fetchSubscription<Model: FetchableUnmanagedModel>(
+        request: NSFetchRequest<Model.ManagedModel>,
+        changeTrackingRequest: NSFetchRequest<Model.ManagedModel>,
+        of _: Model.Type
+    ) -> AsyncStream<Result<[Model], CoreDataError>> {
+        AsyncStream { continuation in
+            let subscription = FetchSubscription(
+                fetchRequest: request,
+                fetchResultControllerRequest: changeTrackingRequest,
+                context: context.childContext(),
+                continuation: continuation
+            )
+            continuation.onTermination = { _ in
+                subscription.cancel()
+            }
+            subscription.manualFetch()
+        }
+    }
+
+    /// Fetch items from the store with a ``NSFetchRequest`` and receive updates as the store changes.
     @inlinable
     public func fetchThrowingSubscription<Model: FetchableUnmanagedModel>(
         _ request: NSFetchRequest<Model.ManagedModel>,
@@ -48,6 +73,31 @@ extension CoreDataRepository {
         AsyncThrowingStream { continuation in
             let subscription = FetchThrowingSubscription(
                 request: request,
+                context: context.childContext(),
+                continuation: continuation
+            )
+            continuation.onTermination = { _ in
+                subscription.cancel()
+            }
+            subscription.manualFetch()
+        }
+    }
+
+    /// Fetch items from the store with a ``NSFetchRequest`` and receive updates as the store changes.
+    ///
+    /// This endpoint allows separate fetch requests for fetching and change tracking. There are times where CoreData
+    /// will not recognize changes with a specific predicate. The fix, is to use a simplified predicate for change
+    /// tracking and the full predicate for fetching.
+    @inlinable
+    public func fetchThrowingSubscription<Model: FetchableUnmanagedModel>(
+        request: NSFetchRequest<Model.ManagedModel>,
+        changeTrackingRequest: NSFetchRequest<Model.ManagedModel>,
+        of _: Model.Type
+    ) -> AsyncThrowingStream<[Model], Error> {
+        AsyncThrowingStream { continuation in
+            let subscription = FetchThrowingSubscription(
+                fetchRequest: request,
+                fetchResultControllerRequest: changeTrackingRequest,
                 context: context.childContext(),
                 continuation: continuation
             )

--- a/Sources/CoreDataRepository/Internal/AggregateSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/AggregateSubscription.swift
@@ -40,7 +40,6 @@ final class AggregateSubscription<Value: Numeric & Sendable>: Subscription<Value
     }
 
     @usableFromInline
-    // swiftlint:disable:next function_body_length
     convenience init(
         function: CoreDataRepository.AggregateFunction,
         context: NSManagedObjectContext,
@@ -132,7 +131,20 @@ final class AggregateSubscription<Value: Numeric & Sendable>: Subscription<Value
                 context: context,
                 continuation: continuation
             )
-            fail(.propertyDoesNotMatchEntity)
+            guard let entityName = entityDesc.name ?? entityDesc.managedObjectClassName else {
+                fail(.propertyDoesNotMatchEntity(description: nil))
+                return
+            }
+            guard let attributeEntityName = attributeDesc.entity.name ?? attributeDesc.entity.managedObjectClassName
+            else {
+                fail(.propertyDoesNotMatchEntity(description: entityName))
+                return
+            }
+            fail(
+                .propertyDoesNotMatchEntity(
+                    description: "\(entityName) != \(attributeDesc.name).\(attributeEntityName)"
+                )
+            )
             return
         }
         self.init(

--- a/Sources/CoreDataRepository/Internal/AggregateSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/AggregateSubscription.swift
@@ -52,31 +52,13 @@ final class AggregateSubscription<Value: Numeric & Sendable>: Subscription<Value
     ) {
         let request: NSFetchRequest<NSDictionary>
         do {
-            request = try NSFetchRequest<NSDictionary>.request(
+            request = try NSFetchRequest.request(
                 function: function,
                 predicate: predicate,
                 entityDesc: entityDesc,
                 attributeDesc: attributeDesc,
                 groupBy: groupBy
             )
-        } catch let error as CoreDataError {
-            self.init(
-                fetchRequest: NSFetchRequest(),
-                fetchResultControllerRequest: NSFetchRequest(),
-                context: context,
-                continuation: continuation
-            )
-            self.fail(error)
-            return
-        } catch let error as CocoaError {
-            self.init(
-                fetchRequest: NSFetchRequest(),
-                fetchResultControllerRequest: NSFetchRequest(),
-                context: context,
-                continuation: continuation
-            )
-            self.fail(.cocoa(error))
-            return
         } catch {
             self.init(
                 fetchRequest: NSFetchRequest(),
@@ -84,7 +66,7 @@ final class AggregateSubscription<Value: Numeric & Sendable>: Subscription<Value
                 context: context,
                 continuation: continuation
             )
-            fail(.unknown(error as NSError))
+            fail(error)
             return
         }
         guard entityDesc == attributeDesc.entity else {
@@ -111,5 +93,53 @@ final class AggregateSubscription<Value: Numeric & Sendable>: Subscription<Value
             return
         }
         self.init(request: request, context: context, continuation: continuation)
+    }
+
+    @usableFromInline
+    convenience init(
+        function: CoreDataRepository.AggregateFunction,
+        context: NSManagedObjectContext,
+        predicate: NSPredicate,
+        changeTrackingRequest: NSFetchRequest<NSManagedObject>,
+        entityDesc: NSEntityDescription,
+        attributeDesc: NSAttributeDescription,
+        groupBy: NSAttributeDescription? = nil,
+        continuation: AsyncStream<Result<Value, CoreDataError>>.Continuation
+    ) {
+        let request: NSFetchRequest<NSDictionary>
+        do {
+            request = try NSFetchRequest.request(
+                function: function,
+                predicate: predicate,
+                entityDesc: entityDesc,
+                attributeDesc: attributeDesc,
+                groupBy: groupBy
+            )
+        } catch {
+            self.init(
+                fetchRequest: NSFetchRequest(),
+                fetchResultControllerRequest: NSFetchRequest(),
+                context: context,
+                continuation: continuation
+            )
+            fail(error)
+            return
+        }
+        guard entityDesc == attributeDesc.entity else {
+            self.init(
+                fetchRequest: NSFetchRequest(),
+                fetchResultControllerRequest: NSFetchRequest(),
+                context: context,
+                continuation: continuation
+            )
+            fail(.propertyDoesNotMatchEntity)
+            return
+        }
+        self.init(
+            fetchRequest: request,
+            fetchResultControllerRequest: changeTrackingRequest,
+            context: context,
+            continuation: continuation
+        )
     }
 }

--- a/Sources/CoreDataRepository/Internal/AggregateThrowingSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/AggregateThrowingSubscription.swift
@@ -52,35 +52,17 @@ final class AggregateThrowingSubscription<Value: Numeric & Sendable>: ThrowingSu
         entityDesc: NSEntityDescription,
         attributeDesc: NSAttributeDescription,
         groupBy: NSAttributeDescription? = nil,
-        continuation: AsyncThrowingStream<Value, Error>.Continuation
+        continuation: AsyncThrowingStream<Value, any Error>.Continuation
     ) {
         let request: NSFetchRequest<NSDictionary>
         do {
-            request = try NSFetchRequest<NSDictionary>.request(
+            request = try NSFetchRequest.request(
                 function: function,
                 predicate: predicate,
                 entityDesc: entityDesc,
                 attributeDesc: attributeDesc,
                 groupBy: groupBy
             )
-        } catch let error as CoreDataError {
-            self.init(
-                fetchRequest: NSFetchRequest(),
-                fetchResultControllerRequest: NSFetchRequest(),
-                context: context,
-                continuation: continuation
-            )
-            self.fail(error)
-            return
-        } catch let error as CocoaError {
-            self.init(
-                fetchRequest: NSFetchRequest(),
-                fetchResultControllerRequest: NSFetchRequest(),
-                context: context,
-                continuation: continuation
-            )
-            self.fail(.cocoa(error))
-            return
         } catch {
             self.init(
                 fetchRequest: NSFetchRequest(),
@@ -88,7 +70,7 @@ final class AggregateThrowingSubscription<Value: Numeric & Sendable>: ThrowingSu
                 context: context,
                 continuation: continuation
             )
-            fail(.unknown(error as NSError))
+            fail(error)
             return
         }
         guard entityDesc == attributeDesc.entity else {
@@ -115,5 +97,53 @@ final class AggregateThrowingSubscription<Value: Numeric & Sendable>: ThrowingSu
             return
         }
         self.init(request: request, context: context, continuation: continuation)
+    }
+
+    @usableFromInline
+    convenience init(
+        function: CoreDataRepository.AggregateFunction,
+        context: NSManagedObjectContext,
+        predicate: NSPredicate,
+        changeTrackingRequest: NSFetchRequest<NSManagedObject>,
+        entityDesc: NSEntityDescription,
+        attributeDesc: NSAttributeDescription,
+        groupBy: NSAttributeDescription? = nil,
+        continuation: AsyncThrowingStream<Value, any Error>.Continuation
+    ) {
+        let request: NSFetchRequest<NSDictionary>
+        do {
+            request = try NSFetchRequest.request(
+                function: function,
+                predicate: predicate,
+                entityDesc: entityDesc,
+                attributeDesc: attributeDesc,
+                groupBy: groupBy
+            )
+        } catch {
+            self.init(
+                fetchRequest: NSFetchRequest(),
+                fetchResultControllerRequest: NSFetchRequest(),
+                context: context,
+                continuation: continuation
+            )
+            fail(error)
+            return
+        }
+        guard entityDesc == attributeDesc.entity else {
+            self.init(
+                fetchRequest: NSFetchRequest(),
+                fetchResultControllerRequest: NSFetchRequest(),
+                context: context,
+                continuation: continuation
+            )
+            fail(.propertyDoesNotMatchEntity)
+            return
+        }
+        self.init(
+            fetchRequest: request,
+            fetchResultControllerRequest: changeTrackingRequest,
+            context: context,
+            continuation: continuation
+        )
     }
 }

--- a/Sources/CoreDataRepository/Internal/AggregateThrowingSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/AggregateThrowingSubscription.swift
@@ -44,7 +44,6 @@ final class AggregateThrowingSubscription<Value: Numeric & Sendable>: ThrowingSu
     }
 
     @usableFromInline
-    // swiftlint:disable:next function_body_length
     convenience init(
         function: CoreDataRepository.AggregateFunction,
         context: NSManagedObjectContext,
@@ -136,7 +135,20 @@ final class AggregateThrowingSubscription<Value: Numeric & Sendable>: ThrowingSu
                 context: context,
                 continuation: continuation
             )
-            fail(.propertyDoesNotMatchEntity)
+            guard let entityName = entityDesc.name ?? entityDesc.managedObjectClassName else {
+                fail(.propertyDoesNotMatchEntity(description: nil))
+                return
+            }
+            guard let attributeEntityName = attributeDesc.entity.name ?? attributeDesc.entity.managedObjectClassName
+            else {
+                fail(.propertyDoesNotMatchEntity(description: entityName))
+                return
+            }
+            fail(
+                .propertyDoesNotMatchEntity(
+                    description: "\(entityName) != \(attributeDesc.name).\(attributeEntityName)"
+                )
+            )
             return
         }
         self.init(

--- a/Sources/CoreDataRepository/Internal/CountSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/CountSubscription.swift
@@ -14,12 +14,12 @@ final class CountSubscription<Value: Numeric & Sendable>: Subscription<Value, NS
 {
     @usableFromInline
     override func fetch() {
-        frc.managedObjectContext.perform { [weak self, frc] in
+        frc.managedObjectContext.perform { [weak self, frc, request] in
             if (frc.fetchedObjects ?? []).isEmpty {
                 self?.start()
             }
             do {
-                let count = try frc.managedObjectContext.count(for: frc.fetchRequest)
+                let count = try frc.managedObjectContext.count(for: request)
                 self?.send(Value(exactly: count) ?? Value.zero)
             } catch let error as CocoaError {
                 self?.fail(.cocoa(error))
@@ -38,28 +38,10 @@ final class CountSubscription<Value: Numeric & Sendable>: Subscription<Value, NS
     ) {
         let request: NSFetchRequest<NSDictionary>
         do {
-            request = try NSFetchRequest<NSDictionary>.countRequest(
+            request = try NSFetchRequest.countRequest(
                 predicate: predicate,
                 entityDesc: entityDesc
             )
-        } catch let error as CoreDataError {
-            self.init(
-                fetchRequest: NSFetchRequest(),
-                fetchResultControllerRequest: NSFetchRequest(),
-                context: context,
-                continuation: continuation
-            )
-            self.fail(error)
-            return
-        } catch let error as CocoaError {
-            self.init(
-                fetchRequest: NSFetchRequest(),
-                fetchResultControllerRequest: NSFetchRequest(),
-                context: context,
-                continuation: continuation
-            )
-            self.fail(.cocoa(error))
-            return
         } catch {
             self.init(
                 fetchRequest: NSFetchRequest(),
@@ -67,9 +49,38 @@ final class CountSubscription<Value: Numeric & Sendable>: Subscription<Value, NS
                 context: context,
                 continuation: continuation
             )
-            fail(.unknown(error as NSError))
+            fail(error)
             return
         }
         self.init(request: request, context: context, continuation: continuation)
+    }
+
+    @usableFromInline
+    convenience init(
+        context: NSManagedObjectContext,
+        predicate: NSPredicate,
+        changeTrackingRequest: NSFetchRequest<NSManagedObject>,
+        entityDesc: NSEntityDescription,
+        continuation: AsyncStream<Result<Value, CoreDataError>>.Continuation
+    ) {
+        let request: NSFetchRequest<NSDictionary>
+        do {
+            request = try NSFetchRequest.countRequest(predicate: predicate, entityDesc: entityDesc)
+        } catch {
+            self.init(
+                fetchRequest: NSFetchRequest(),
+                fetchResultControllerRequest: NSFetchRequest(),
+                context: context,
+                continuation: continuation
+            )
+            fail(error)
+            return
+        }
+        self.init(
+            fetchRequest: request,
+            fetchResultControllerRequest: changeTrackingRequest,
+            context: context,
+            continuation: continuation
+        )
     }
 }

--- a/Sources/CoreDataRepository/Internal/CountThrowingSubscription.swift
+++ b/Sources/CoreDataRepository/Internal/CountThrowingSubscription.swift
@@ -18,12 +18,12 @@ final class CountThrowingSubscription<Value: Numeric & Sendable>: ThrowingSubscr
 {
     @usableFromInline
     override func fetch() {
-        frc.managedObjectContext.perform { [weak self, frc] in
+        frc.managedObjectContext.perform { [weak self, frc, request] in
             if (frc.fetchedObjects ?? []).isEmpty {
                 self?.start()
             }
             do {
-                let count = try frc.managedObjectContext.count(for: frc.fetchRequest)
+                let count = try frc.managedObjectContext.count(for: request)
                 self?.send(Value(exactly: count) ?? Value.zero)
             } catch let error as CocoaError {
                 self?.fail(.cocoa(error))
@@ -38,32 +38,14 @@ final class CountThrowingSubscription<Value: Numeric & Sendable>: ThrowingSubscr
         context: NSManagedObjectContext,
         predicate: NSPredicate,
         entityDesc: NSEntityDescription,
-        continuation: AsyncThrowingStream<Value, Error>.Continuation
+        continuation: AsyncThrowingStream<Value, any Error>.Continuation
     ) {
         let request: NSFetchRequest<NSDictionary>
         do {
-            request = try NSFetchRequest<NSDictionary>.countRequest(
+            request = try NSFetchRequest.countRequest(
                 predicate: predicate,
                 entityDesc: entityDesc
             )
-        } catch let error as CoreDataError {
-            self.init(
-                fetchRequest: NSFetchRequest(),
-                fetchResultControllerRequest: NSFetchRequest(),
-                context: context,
-                continuation: continuation
-            )
-            self.fail(error)
-            return
-        } catch let error as CocoaError {
-            self.init(
-                fetchRequest: NSFetchRequest(),
-                fetchResultControllerRequest: NSFetchRequest(),
-                context: context,
-                continuation: continuation
-            )
-            self.fail(.cocoa(error))
-            return
         } catch {
             self.init(
                 fetchRequest: NSFetchRequest(),
@@ -71,9 +53,41 @@ final class CountThrowingSubscription<Value: Numeric & Sendable>: ThrowingSubscr
                 context: context,
                 continuation: continuation
             )
-            fail(.unknown(error as NSError))
+            fail(error)
             return
         }
         self.init(request: request, context: context, continuation: continuation)
+    }
+
+    @usableFromInline
+    convenience init(
+        context: NSManagedObjectContext,
+        predicate: NSPredicate,
+        changeTrackingRequest: NSFetchRequest<NSManagedObject>,
+        entityDesc: NSEntityDescription,
+        continuation: AsyncThrowingStream<Value, any Error>.Continuation
+    ) {
+        let request: NSFetchRequest<NSDictionary>
+        do {
+            request = try NSFetchRequest.countRequest(
+                predicate: predicate,
+                entityDesc: entityDesc
+            )
+        } catch {
+            self.init(
+                fetchRequest: NSFetchRequest(),
+                fetchResultControllerRequest: NSFetchRequest(),
+                context: context,
+                continuation: continuation
+            )
+            fail(error)
+            return
+        }
+        self.init(
+            fetchRequest: request,
+            fetchResultControllerRequest: changeTrackingRequest,
+            context: context,
+            continuation: continuation
+        )
     }
 }

--- a/Sources/CoreDataRepository/Internal/NSFetchRequest+AggregateHelpers.swift
+++ b/Sources/CoreDataRepository/Internal/NSFetchRequest+AggregateHelpers.swift
@@ -16,7 +16,7 @@ extension NSFetchRequest<NSDictionary> {
         entityDesc: NSEntityDescription,
         attributeDesc: NSAttributeDescription,
         groupBy: NSAttributeDescription? = nil
-    ) throws -> NSFetchRequest<NSDictionary> {
+    ) throws(CoreDataError) -> NSFetchRequest<NSDictionary> {
         guard let entityName = entityDesc.name else {
             throw CoreDataError.noEntityNameFound
         }
@@ -42,7 +42,7 @@ extension NSFetchRequest<NSDictionary> {
     static func countRequest(
         predicate: NSPredicate,
         entityDesc: NSEntityDescription
-    ) throws -> NSFetchRequest<NSDictionary> {
+    ) throws(CoreDataError) -> NSFetchRequest<NSDictionary> {
         guard let attributeDesc = entityDesc.attributesByName.values.first else {
             throw CoreDataError.atLeastOneAttributeDescRequired
         }

--- a/Tests/CoreDataRepositoryTests/AggregateTests.swift
+++ b/Tests/CoreDataRepositoryTests/AggregateTests.swift
@@ -160,6 +160,63 @@ extension CoreDataRepositoryTests {
         }
 
         @Test(arguments: [false, true])
+        func countSubscriptionWithSplitFetchRequests(inTransaction: Bool) async throws {
+            let changeTrackingRequest = try #require(UnmanagedModel_UuidId
+                .managedFetchRequest() as? NSFetchRequest<NSManagedObject>)
+            changeTrackingRequest.predicate = NSComparisonPredicate(
+                leftExpression: NSExpression(forKeyPath: \ManagedModel_UuidId.int),
+                rightExpression: NSExpression(forConstantValue: 30),
+                modifier: .direct,
+                type: .notEqualTo
+            )
+            changeTrackingRequest.sortDescriptors = [
+                NSSortDescriptor(keyPath: \ManagedModel_UuidId.int, ascending: true),
+            ]
+            let fetchPredicate = NSPredicate(value: true)
+            let task = Task {
+                var resultCount = 0
+                let stream = if inTransaction {
+                    try await repository.withTransaction { _ in
+                        repository
+                            .countSubscription(
+                                predicate: fetchPredicate,
+                                changeTrackingRequest: changeTrackingRequest,
+                                entityDesc: ManagedModel_UuidId.entity(),
+                                as: Int.self
+                            )
+                    }
+                } else {
+                    repository
+                        .countSubscription(
+                            predicate: fetchPredicate,
+                            changeTrackingRequest: changeTrackingRequest,
+                            entityDesc: ManagedModel_UuidId.entity(),
+                            as: Int.self
+                        )
+                }
+                for await _count in stream {
+                    let count = try _count.get()
+                    resultCount += 1
+                    switch resultCount {
+                    case 1:
+                        expectNoDifference(count, 5, "Result value (count) should equal number of values.")
+                        try delete(managedId: #require(objectIds.last))
+                        await Task.yield()
+                    case 2:
+                        expectNoDifference(count, 4, "Count should match expected value after deleting one value.")
+                        return resultCount
+                    default:
+                        Issue.record("Not expecting any values past the first two.")
+                        return resultCount
+                    }
+                }
+                return resultCount
+            }
+            let finalCount = try await task.value
+            expectNoDifference(finalCount, 2)
+        }
+
+        @Test(arguments: [false, true])
         func countThrowingSubscription(inTransaction: Bool) async throws {
             let task = Task {
                 var resultCount = 0
@@ -176,6 +233,61 @@ extension CoreDataRepositoryTests {
                     repository
                         .countThrowingSubscription(
                             predicate: NSPredicate(value: true),
+                            entityDesc: ManagedModel_UuidId.entity(),
+                            as: Int.self
+                        )
+                }
+                for try await count in stream {
+                    resultCount += 1
+                    switch resultCount {
+                    case 1:
+                        expectNoDifference(count, 5, "Result value (count) should equal number of values.")
+                        try delete(managedId: #require(objectIds.last))
+                        await Task.yield()
+                    case 2:
+                        expectNoDifference(count, 4, "Count should match expected value after deleting one value.")
+                        return resultCount
+                    default:
+                        Issue.record("Not expecting any values past the first two.")
+                        return resultCount
+                    }
+                }
+                return resultCount
+            }
+            let finalCount = try await task.value
+            expectNoDifference(finalCount, 2)
+        }
+
+        @Test(arguments: [false, true])
+        func countThrowingSubscriptionWithSplitFetchRequests(inTransaction: Bool) async throws {
+            let changeTrackingRequest = try #require(UnmanagedModel_UuidId
+                .managedFetchRequest() as? NSFetchRequest<NSManagedObject>)
+            changeTrackingRequest.predicate = NSComparisonPredicate(
+                leftExpression: NSExpression(forKeyPath: \ManagedModel_UuidId.int),
+                rightExpression: NSExpression(forConstantValue: 30),
+                modifier: .direct,
+                type: .notEqualTo
+            )
+            changeTrackingRequest.sortDescriptors = [
+                NSSortDescriptor(keyPath: \ManagedModel_UuidId.int, ascending: true),
+            ]
+            let task = Task {
+                var resultCount = 0
+                let stream = if inTransaction {
+                    try await repository.withTransaction { _ in
+                        repository
+                            .countThrowingSubscription(
+                                predicate: NSPredicate(value: true),
+                                changeTrackingRequest: changeTrackingRequest,
+                                entityDesc: ManagedModel_UuidId.entity(),
+                                as: Int.self
+                            )
+                    }
+                } else {
+                    repository
+                        .countThrowingSubscription(
+                            predicate: NSPredicate(value: true),
+                            changeTrackingRequest: changeTrackingRequest,
                             entityDesc: ManagedModel_UuidId.entity(),
                             as: Int.self
                         )
@@ -323,6 +435,72 @@ extension CoreDataRepositoryTests {
         }
 
         @Test(arguments: [false, true])
+        func sumSubscriptionWithSplitFetchRequests(inTransaction: Bool) async throws {
+            let changeTrackingRequest = try #require(UnmanagedModel_UuidId
+                .managedFetchRequest() as? NSFetchRequest<NSManagedObject>)
+            changeTrackingRequest.predicate = NSComparisonPredicate(
+                leftExpression: NSExpression(forKeyPath: \ManagedModel_UuidId.int),
+                rightExpression: NSExpression(forConstantValue: 30),
+                modifier: .direct,
+                type: .notEqualTo
+            )
+            changeTrackingRequest.sortDescriptors = [
+                NSSortDescriptor(keyPath: \ManagedModel_UuidId.int, ascending: true),
+            ]
+            let task = Task {
+                var resultCount = 0
+                let stream = if inTransaction {
+                    try await repository.withTransaction { _ in
+                        try repository.sumSubscription(
+                            predicate: NSPredicate(value: true),
+                            changeTrackingRequest: changeTrackingRequest,
+                            entityDesc: ManagedModel_UuidId.entity(),
+                            attributeDesc: #require(
+                                ManagedModel_UuidId.entity().attributesByName.values
+                                    .first(where: { $0.name == "decimal" })
+                            ),
+                            as: Decimal.self
+                        )
+                    }
+                } else {
+                    try repository.sumSubscription(
+                        predicate: NSPredicate(value: true),
+                        changeTrackingRequest: changeTrackingRequest,
+                        entityDesc: ManagedModel_UuidId.entity(),
+                        attributeDesc: #require(
+                            ManagedModel_UuidId.entity().attributesByName.values
+                                .first(where: { $0.name == "decimal" })
+                        ),
+                        as: Decimal.self
+                    )
+                }
+                for await _sum in stream {
+                    let sum = try _sum.get()
+                    resultCount += 1
+                    switch resultCount {
+                    case 1:
+                        expectNoDifference(sum, 150, "Result value (sum) should equal number of values.")
+                        try delete(managedId: #require(objectIds.last))
+                        await Task.yield()
+                    case 2:
+                        expectNoDifference(
+                            sum,
+                            100,
+                            "Result value (sum) should match expected value after deleting one value."
+                        )
+                        return resultCount
+                    default:
+                        Issue.record("Not expecting any values past the first two.")
+                        return resultCount
+                    }
+                }
+                return resultCount
+            }
+            let finalCount = try await task.value
+            expectNoDifference(finalCount, 2)
+        }
+
+        @Test(arguments: [false, true])
         func sumThrowingSubscription(inTransaction: Bool) async throws {
             let task = Task {
                 var resultCount = 0
@@ -341,6 +519,71 @@ extension CoreDataRepositoryTests {
                 } else {
                     try repository.sumThrowingSubscription(
                         predicate: NSPredicate(value: true),
+                        entityDesc: ManagedModel_UuidId.entity(),
+                        attributeDesc: #require(
+                            ManagedModel_UuidId.entity().attributesByName.values
+                                .first(where: { $0.name == "decimal" })
+                        ),
+                        as: Decimal.self
+                    )
+                }
+                for try await sum in stream {
+                    resultCount += 1
+                    switch resultCount {
+                    case 1:
+                        expectNoDifference(sum, 150, "Result value (sum) should equal number of values.")
+                        try delete(managedId: #require(objectIds.last))
+                        await Task.yield()
+                    case 2:
+                        expectNoDifference(
+                            sum,
+                            100,
+                            "Result value (sum) should match expected value after deleting one value."
+                        )
+                        return resultCount
+                    default:
+                        Issue.record("Not expecting any values past the first two.")
+                        return resultCount
+                    }
+                }
+                return resultCount
+            }
+            let finalCount = try await task.value
+            expectNoDifference(finalCount, 2)
+        }
+
+        @Test(arguments: [false, true])
+        func sumThrowingSubscriptionWithSplitFetchRequests(inTransaction: Bool) async throws {
+            let changeTrackingRequest = try #require(UnmanagedModel_UuidId
+                .managedFetchRequest() as? NSFetchRequest<NSManagedObject>)
+            changeTrackingRequest.predicate = NSComparisonPredicate(
+                leftExpression: NSExpression(forKeyPath: \ManagedModel_UuidId.int),
+                rightExpression: NSExpression(forConstantValue: 30),
+                modifier: .direct,
+                type: .notEqualTo
+            )
+            changeTrackingRequest.sortDescriptors = [
+                NSSortDescriptor(keyPath: \ManagedModel_UuidId.int, ascending: true),
+            ]
+            let task = Task {
+                var resultCount = 0
+                let stream = if inTransaction {
+                    try await repository.withTransaction { _ in
+                        try repository.sumThrowingSubscription(
+                            predicate: NSPredicate(value: true),
+                            changeTrackingRequest: changeTrackingRequest,
+                            entityDesc: ManagedModel_UuidId.entity(),
+                            attributeDesc: #require(
+                                ManagedModel_UuidId.entity().attributesByName.values
+                                    .first(where: { $0.name == "decimal" })
+                            ),
+                            as: Decimal.self
+                        )
+                    }
+                } else {
+                    try repository.sumThrowingSubscription(
+                        predicate: NSPredicate(value: true),
+                        changeTrackingRequest: changeTrackingRequest,
                         entityDesc: ManagedModel_UuidId.entity(),
                         attributeDesc: #require(
                             ManagedModel_UuidId.entity().attributesByName.values
@@ -504,6 +747,72 @@ extension CoreDataRepositoryTests {
         }
 
         @Test(arguments: [false, true])
+        func averageSubscriptionWithSplitFetchRequests(inTransaction: Bool) async throws {
+            let changeTrackingRequest = try #require(UnmanagedModel_UuidId
+                .managedFetchRequest() as? NSFetchRequest<NSManagedObject>)
+            changeTrackingRequest.predicate = NSComparisonPredicate(
+                leftExpression: NSExpression(forKeyPath: \ManagedModel_UuidId.int),
+                rightExpression: NSExpression(forConstantValue: 30),
+                modifier: .direct,
+                type: .notEqualTo
+            )
+            changeTrackingRequest.sortDescriptors = [
+                NSSortDescriptor(keyPath: \ManagedModel_UuidId.int, ascending: true),
+            ]
+            let task = Task {
+                var resultCount = 0
+                let stream = if inTransaction {
+                    try await repository.withTransaction { _ in
+                        try repository.averageSubscription(
+                            predicate: NSPredicate(value: true),
+                            changeTrackingRequest: changeTrackingRequest,
+                            entityDesc: ManagedModel_UuidId.entity(),
+                            attributeDesc: #require(
+                                ManagedModel_UuidId.entity().attributesByName.values
+                                    .first(where: { $0.name == "decimal" })
+                            ),
+                            as: Decimal.self
+                        )
+                    }
+                } else {
+                    try repository.averageSubscription(
+                        predicate: NSPredicate(value: true),
+                        changeTrackingRequest: changeTrackingRequest,
+                        entityDesc: ManagedModel_UuidId.entity(),
+                        attributeDesc: #require(
+                            ManagedModel_UuidId.entity().attributesByName.values
+                                .first(where: { $0.name == "decimal" })
+                        ),
+                        as: Decimal.self
+                    )
+                }
+                for await _average in stream {
+                    let average = try _average.get()
+                    resultCount += 1
+                    switch resultCount {
+                    case 1:
+                        expectNoDifference(average, 30, "Result value (average) should equal number of values.")
+                        try delete(managedId: #require(objectIds.last))
+                        await Task.yield()
+                    case 2:
+                        expectNoDifference(
+                            average,
+                            25,
+                            "Result value (average) should match expected value after deleting one value."
+                        )
+                        return resultCount
+                    default:
+                        Issue.record("Not expecting any values past the first two.")
+                        return resultCount
+                    }
+                }
+                return resultCount
+            }
+            let finalCount = try await task.value
+            expectNoDifference(finalCount, 2)
+        }
+
+        @Test(arguments: [false, true])
         func averageThrowingSubscription(inTransaction: Bool) async throws {
             let task = Task {
                 var resultCount = 0
@@ -522,6 +831,71 @@ extension CoreDataRepositoryTests {
                 } else {
                     try repository.averageThrowingSubscription(
                         predicate: NSPredicate(value: true),
+                        entityDesc: ManagedModel_UuidId.entity(),
+                        attributeDesc: #require(
+                            ManagedModel_UuidId.entity().attributesByName.values
+                                .first(where: { $0.name == "decimal" })
+                        ),
+                        as: Decimal.self
+                    )
+                }
+                for try await average in stream {
+                    resultCount += 1
+                    switch resultCount {
+                    case 1:
+                        expectNoDifference(average, 30, "Result value (average) should equal number of values.")
+                        try delete(managedId: #require(objectIds.last))
+                        await Task.yield()
+                    case 2:
+                        expectNoDifference(
+                            average,
+                            25,
+                            "Result value (average) should match expected value after deleting one value."
+                        )
+                        return resultCount
+                    default:
+                        Issue.record("Not expecting any values past the first two.")
+                        return resultCount
+                    }
+                }
+                return resultCount
+            }
+            let finalCount = try await task.value
+            expectNoDifference(finalCount, 2)
+        }
+
+        @Test(arguments: [false, true])
+        func averageThrowingSubscriptionWithSplitFetchRequests(inTransaction: Bool) async throws {
+            let changeTrackingRequest = try #require(UnmanagedModel_UuidId
+                .managedFetchRequest() as? NSFetchRequest<NSManagedObject>)
+            changeTrackingRequest.predicate = NSComparisonPredicate(
+                leftExpression: NSExpression(forKeyPath: \ManagedModel_UuidId.int),
+                rightExpression: NSExpression(forConstantValue: 30),
+                modifier: .direct,
+                type: .notEqualTo
+            )
+            changeTrackingRequest.sortDescriptors = [
+                NSSortDescriptor(keyPath: \ManagedModel_UuidId.int, ascending: true),
+            ]
+            let task = Task {
+                var resultCount = 0
+                let stream = if inTransaction {
+                    try await repository.withTransaction { _ in
+                        try repository.averageThrowingSubscription(
+                            predicate: NSPredicate(value: true),
+                            changeTrackingRequest: changeTrackingRequest,
+                            entityDesc: ManagedModel_UuidId.entity(),
+                            attributeDesc: #require(
+                                ManagedModel_UuidId.entity().attributesByName.values
+                                    .first(where: { $0.name == "decimal" })
+                            ),
+                            as: Decimal.self
+                        )
+                    }
+                } else {
+                    try repository.averageThrowingSubscription(
+                        predicate: NSPredicate(value: true),
+                        changeTrackingRequest: changeTrackingRequest,
                         entityDesc: ManagedModel_UuidId.entity(),
                         attributeDesc: #require(
                             ManagedModel_UuidId.entity().attributesByName.values
@@ -685,6 +1059,72 @@ extension CoreDataRepositoryTests {
         }
 
         @Test(arguments: [false, true])
+        func minSubscriptionWithSplitFetchRequests(inTransaction: Bool) async throws {
+            let changeTrackingRequest = try #require(UnmanagedModel_UuidId
+                .managedFetchRequest() as? NSFetchRequest<NSManagedObject>)
+            changeTrackingRequest.predicate = NSComparisonPredicate(
+                leftExpression: NSExpression(forKeyPath: \ManagedModel_UuidId.int),
+                rightExpression: NSExpression(forConstantValue: 30),
+                modifier: .direct,
+                type: .notEqualTo
+            )
+            changeTrackingRequest.sortDescriptors = [
+                NSSortDescriptor(keyPath: \ManagedModel_UuidId.int, ascending: true),
+            ]
+            let task = Task {
+                var resultCount = 0
+                let stream = if inTransaction {
+                    try await repository.withTransaction { _ in
+                        try repository.minSubscription(
+                            predicate: NSPredicate(value: true),
+                            changeTrackingRequest: changeTrackingRequest,
+                            entityDesc: ManagedModel_UuidId.entity(),
+                            attributeDesc: #require(
+                                ManagedModel_UuidId.entity().attributesByName.values
+                                    .first(where: { $0.name == "decimal" })
+                            ),
+                            as: Decimal.self
+                        )
+                    }
+                } else {
+                    try repository.minSubscription(
+                        predicate: NSPredicate(value: true),
+                        changeTrackingRequest: changeTrackingRequest,
+                        entityDesc: ManagedModel_UuidId.entity(),
+                        attributeDesc: #require(
+                            ManagedModel_UuidId.entity().attributesByName.values
+                                .first(where: { $0.name == "decimal" })
+                        ),
+                        as: Decimal.self
+                    )
+                }
+                for await _min in stream {
+                    let min = try _min.get()
+                    resultCount += 1
+                    switch resultCount {
+                    case 1:
+                        expectNoDifference(min, 10, "Result value (min) should equal number of values.")
+                        try delete(managedId: #require(objectIds.last))
+                        await Task.yield()
+                    case 2:
+                        expectNoDifference(
+                            min,
+                            10,
+                            "Result value (min) should match expected value after deleting one value."
+                        )
+                        return resultCount
+                    default:
+                        Issue.record("Not expecting any values past the first two.")
+                        return resultCount
+                    }
+                }
+                return resultCount
+            }
+            let finalCount = try await task.value
+            expectNoDifference(finalCount, 2)
+        }
+
+        @Test(arguments: [false, true])
         func minThrowingSubscription(inTransaction: Bool) async throws {
             let task = Task {
                 var resultCount = 0
@@ -703,6 +1143,71 @@ extension CoreDataRepositoryTests {
                 } else {
                     try repository.minThrowingSubscription(
                         predicate: NSPredicate(value: true),
+                        entityDesc: ManagedModel_UuidId.entity(),
+                        attributeDesc: #require(
+                            ManagedModel_UuidId.entity().attributesByName.values
+                                .first(where: { $0.name == "decimal" })
+                        ),
+                        as: Decimal.self
+                    )
+                }
+                for try await min in stream {
+                    resultCount += 1
+                    switch resultCount {
+                    case 1:
+                        expectNoDifference(min, 10, "Result value (min) should equal number of values.")
+                        try delete(managedId: #require(objectIds.last))
+                        await Task.yield()
+                    case 2:
+                        expectNoDifference(
+                            min,
+                            10,
+                            "Result value (min) should match expected value after deleting one value."
+                        )
+                        return resultCount
+                    default:
+                        Issue.record("Not expecting any values past the first two.")
+                        return resultCount
+                    }
+                }
+                return resultCount
+            }
+            let finalCount = try await task.value
+            expectNoDifference(finalCount, 2)
+        }
+
+        @Test(arguments: [false, true])
+        func minThrowingSubscriptionWithSplitFetchRequests(inTransaction: Bool) async throws {
+            let changeTrackingRequest = try #require(UnmanagedModel_UuidId
+                .managedFetchRequest() as? NSFetchRequest<NSManagedObject>)
+            changeTrackingRequest.predicate = NSComparisonPredicate(
+                leftExpression: NSExpression(forKeyPath: \ManagedModel_UuidId.int),
+                rightExpression: NSExpression(forConstantValue: 30),
+                modifier: .direct,
+                type: .notEqualTo
+            )
+            changeTrackingRequest.sortDescriptors = [
+                NSSortDescriptor(keyPath: \ManagedModel_UuidId.int, ascending: true),
+            ]
+            let task = Task {
+                var resultCount = 0
+                let stream = if inTransaction {
+                    try await repository.withTransaction { _ in
+                        try repository.minThrowingSubscription(
+                            predicate: NSPredicate(value: true),
+                            changeTrackingRequest: changeTrackingRequest,
+                            entityDesc: ManagedModel_UuidId.entity(),
+                            attributeDesc: #require(
+                                ManagedModel_UuidId.entity().attributesByName.values
+                                    .first(where: { $0.name == "decimal" })
+                            ),
+                            as: Decimal.self
+                        )
+                    }
+                } else {
+                    try repository.minThrowingSubscription(
+                        predicate: NSPredicate(value: true),
+                        changeTrackingRequest: changeTrackingRequest,
                         entityDesc: ManagedModel_UuidId.entity(),
                         attributeDesc: #require(
                             ManagedModel_UuidId.entity().attributesByName.values
@@ -866,6 +1371,72 @@ extension CoreDataRepositoryTests {
         }
 
         @Test(arguments: [false, true])
+        func maxSubscriptionWithSplitFetchRequests(inTransaction: Bool) async throws {
+            let changeTrackingRequest = try #require(UnmanagedModel_UuidId
+                .managedFetchRequest() as? NSFetchRequest<NSManagedObject>)
+            changeTrackingRequest.predicate = NSComparisonPredicate(
+                leftExpression: NSExpression(forKeyPath: \ManagedModel_UuidId.int),
+                rightExpression: NSExpression(forConstantValue: 30),
+                modifier: .direct,
+                type: .notEqualTo
+            )
+            changeTrackingRequest.sortDescriptors = [
+                NSSortDescriptor(keyPath: \ManagedModel_UuidId.int, ascending: true),
+            ]
+            let task = Task {
+                var resultCount = 0
+                let stream = if inTransaction {
+                    try await repository.withTransaction { _ in
+                        try repository.maxSubscription(
+                            predicate: NSPredicate(value: true),
+                            changeTrackingRequest: changeTrackingRequest,
+                            entityDesc: ManagedModel_UuidId.entity(),
+                            attributeDesc: #require(
+                                ManagedModel_UuidId.entity().attributesByName.values
+                                    .first(where: { $0.name == "decimal" })
+                            ),
+                            as: Decimal.self
+                        )
+                    }
+                } else {
+                    try repository.maxSubscription(
+                        predicate: NSPredicate(value: true),
+                        changeTrackingRequest: changeTrackingRequest,
+                        entityDesc: ManagedModel_UuidId.entity(),
+                        attributeDesc: #require(
+                            ManagedModel_UuidId.entity().attributesByName.values
+                                .first(where: { $0.name == "decimal" })
+                        ),
+                        as: Decimal.self
+                    )
+                }
+                for await _max in stream {
+                    let max = try _max.get()
+                    resultCount += 1
+                    switch resultCount {
+                    case 1:
+                        expectNoDifference(max, 50, "Result value (max) should equal number of values.")
+                        try delete(managedId: #require(objectIds.last))
+                        await Task.yield()
+                    case 2:
+                        expectNoDifference(
+                            max,
+                            40,
+                            "Result value (max) should match expected value after deleting one value."
+                        )
+                        return resultCount
+                    default:
+                        Issue.record("Not expecting any values past the first two.")
+                        return resultCount
+                    }
+                }
+                return resultCount
+            }
+            let finalCount = try await task.value
+            expectNoDifference(finalCount, 2)
+        }
+
+        @Test(arguments: [false, true])
         func maxThrowingSubscription(inTransaction: Bool) async throws {
             let task = Task {
                 var resultCount = 0
@@ -884,6 +1455,71 @@ extension CoreDataRepositoryTests {
                 } else {
                     try repository.maxThrowingSubscription(
                         predicate: NSPredicate(value: true),
+                        entityDesc: ManagedModel_UuidId.entity(),
+                        attributeDesc: #require(
+                            ManagedModel_UuidId.entity().attributesByName.values
+                                .first(where: { $0.name == "decimal" })
+                        ),
+                        as: Decimal.self
+                    )
+                }
+                for try await max in stream {
+                    resultCount += 1
+                    switch resultCount {
+                    case 1:
+                        expectNoDifference(max, 50, "Result value (max) should equal number of values.")
+                        try delete(managedId: #require(objectIds.last))
+                        await Task.yield()
+                    case 2:
+                        expectNoDifference(
+                            max,
+                            40,
+                            "Result value (max) should match expected value after deleting one value."
+                        )
+                        return resultCount
+                    default:
+                        Issue.record("Not expecting any values past the first two.")
+                        return resultCount
+                    }
+                }
+                return resultCount
+            }
+            let finalCount = try await task.value
+            expectNoDifference(finalCount, 2)
+        }
+
+        @Test(arguments: [false, true])
+        func maxThrowingSubscriptionWithSplitFetchRequests(inTransaction: Bool) async throws {
+            let changeTrackingRequest = try #require(UnmanagedModel_UuidId
+                .managedFetchRequest() as? NSFetchRequest<NSManagedObject>)
+            changeTrackingRequest.predicate = NSComparisonPredicate(
+                leftExpression: NSExpression(forKeyPath: \ManagedModel_UuidId.int),
+                rightExpression: NSExpression(forConstantValue: 30),
+                modifier: .direct,
+                type: .notEqualTo
+            )
+            changeTrackingRequest.sortDescriptors = [
+                NSSortDescriptor(keyPath: \ManagedModel_UuidId.int, ascending: true),
+            ]
+            let task = Task {
+                var resultCount = 0
+                let stream = if inTransaction {
+                    try await repository.withTransaction { _ in
+                        try repository.maxThrowingSubscription(
+                            predicate: NSPredicate(value: true),
+                            changeTrackingRequest: changeTrackingRequest,
+                            entityDesc: ManagedModel_UuidId.entity(),
+                            attributeDesc: #require(
+                                ManagedModel_UuidId.entity().attributesByName.values
+                                    .first(where: { $0.name == "decimal" })
+                            ),
+                            as: Decimal.self
+                        )
+                    }
+                } else {
+                    try repository.maxThrowingSubscription(
+                        predicate: NSPredicate(value: true),
+                        changeTrackingRequest: changeTrackingRequest,
                         entityDesc: ManagedModel_UuidId.entity(),
                         attributeDesc: #require(
                             ManagedModel_UuidId.entity().attributesByName.values

--- a/Tests/CoreDataRepositoryTests/FetchTests.swift
+++ b/Tests/CoreDataRepositoryTests/FetchTests.swift
@@ -111,6 +111,62 @@ extension CoreDataRepositoryTests {
         }
 
         @Test(arguments: [false, true])
+        func fetchSubscriptionSuccessWithSplitFetchRequests(inTransaction: Bool) async throws {
+            let changeTrackingRequest = Self.fetchRequest()
+            changeTrackingRequest.predicate = NSComparisonPredicate(
+                leftExpression: NSExpression(forKeyPath: \ManagedModel_UuidId.int),
+                rightExpression: NSExpression(forConstantValue: 3),
+                modifier: .direct,
+                type: .notEqualTo
+            )
+            let task = Task {
+                var resultCount = 0
+                let stream = if inTransaction {
+                    try await repository.withTransaction { _ in
+                        repository
+                            .fetchSubscription(
+                                request: Self.fetchRequest(),
+                                changeTrackingRequest: changeTrackingRequest,
+                                of: FetchableModel_UuidId.self
+                            )
+                    }
+                } else {
+                    repository
+                        .fetchSubscription(
+                            request: Self.fetchRequest(),
+                            changeTrackingRequest: changeTrackingRequest,
+                            of: FetchableModel_UuidId.self
+                        )
+                }
+                for await _items in stream {
+                    let items = try _items.get()
+                    resultCount += 1
+                    switch resultCount {
+                    case 1:
+                        expectNoDifference(items.count, 5, "Result items count should match expectation")
+                        expectNoDifference(items, expectedValues, "Result items should match expectations")
+                        try delete(managedId: #require(objectIds.last))
+                        await Task.yield()
+                    case 2:
+                        expectNoDifference(items.count, 4, "Result items count should match expectation")
+                        expectNoDifference(
+                            items,
+                            Array(expectedValues[0 ... 3]),
+                            "Result items should match expectations"
+                        )
+                        return resultCount
+                    default:
+                        Issue.record("Not expecting any values past the first two.")
+                        return resultCount
+                    }
+                }
+                return resultCount
+            }
+            let finalCount = try await task.value
+            expectNoDifference(finalCount, 2)
+        }
+
+        @Test(arguments: [false, true])
         func fetchThrowingSubscriptionSuccess(inTransaction: Bool) async throws {
             let task = Task {
                 var resultCount = 0
@@ -124,6 +180,59 @@ extension CoreDataRepositoryTests {
                 } else {
                     repository.fetchThrowingSubscription(
                         Self.fetchRequest(),
+                        of: FetchableModel_UuidId.self
+                    )
+                }
+                for try await items in stream {
+                    resultCount += 1
+                    switch resultCount {
+                    case 1:
+                        expectNoDifference(items.count, 5, "Result items count should match expectation")
+                        expectNoDifference(items, expectedValues, "Result items should match expectations")
+                        try delete(managedId: #require(objectIds.last))
+                        await Task.yield()
+                    case 2:
+                        expectNoDifference(items.count, 4, "Result items count should match expectation")
+                        expectNoDifference(
+                            items,
+                            Array(expectedValues[0 ... 3]),
+                            "Result items should match expectations"
+                        )
+                        return resultCount
+                    default:
+                        Issue.record("Not expecting any values past the first two.")
+                        return resultCount
+                    }
+                }
+                return resultCount
+            }
+            let finalCount = try await task.value
+            expectNoDifference(finalCount, 2)
+        }
+
+        @Test(arguments: [false, true])
+        func fetchThrowingSubscriptionSuccessWithSplitFetchRequests(inTransaction: Bool) async throws {
+            let changeTrackingRequest = Self.fetchRequest()
+            changeTrackingRequest.predicate = NSComparisonPredicate(
+                leftExpression: NSExpression(forKeyPath: \ManagedModel_UuidId.int),
+                rightExpression: NSExpression(forConstantValue: 3),
+                modifier: .direct,
+                type: .notEqualTo
+            )
+            let task = Task {
+                var resultCount = 0
+                let stream = if inTransaction {
+                    try await repository.withTransaction { _ in
+                        repository.fetchThrowingSubscription(
+                            request: Self.fetchRequest(),
+                            changeTrackingRequest: changeTrackingRequest,
+                            of: FetchableModel_UuidId.self
+                        )
+                    }
+                } else {
+                    repository.fetchThrowingSubscription(
+                        request: Self.fetchRequest(),
+                        changeTrackingRequest: changeTrackingRequest,
                         of: FetchableModel_UuidId.self
                     )
                 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,7 @@
+[tools]
+swiftformat = "latest"
+swiftlint = "latest"
+
+[tool_alias]
+swiftformat = 'asdf:https://github.com/MFB-Technologies-Inc/asdf-swiftformat'
+swiftlint = 'asdf:https://github.com/MFB-Technologies-Inc/asdf-swiftlint'


### PR DESCRIPTION
There are cases where change tracking can't work with the full predicate used for fetching. We've run into an instance of that with Align. Allowing different predicates for fetching and change tracking is the best way forward.