### PR TITLE
Fix incorrect error descriptions

### DIFF
--- a/Sources/CoreDataRepository/FetchableUnmanagedModel.swift
+++ b/Sources/CoreDataRepository/FetchableUnmanagedModel.swift
@@ -70,6 +70,9 @@ public protocol FetchableUnmanagedModel: Sendable {
 
     /// A description of the context from where an error is thrown
     var errorDescription: String { get }
+
+    /// A description of the context from where an error is thrown but there is no instance `self` to use
+    static var errorDescription: String { get }
 }
 
 extension FetchableUnmanagedModel {
@@ -83,6 +86,11 @@ extension FetchableUnmanagedModel {
 
     @inlinable
     public var errorDescription: String {
+        "\(Self.self)"
+    }
+
+    @inlinable
+    public static var errorDescription: String {
         "\(Self.self)"
     }
 }

--- a/Sources/CoreDataRepository/IdentifiedUnmanagedModel.swift
+++ b/Sources/CoreDataRepository/IdentifiedUnmanagedModel.swift
@@ -32,11 +32,15 @@ extension IdentifiedUnmanagedModel {
         let fetchResult = try context.fetch(request)
         guard let managed = fetchResult.first, fetchResult.count == 1 else {
             throw CoreDataError
-                .noMatchFoundWhenReadingItem(description: "\(Self.self) -- id: \(errorDescription(for: id))")
+                .noMatchFoundWhenReadingItem(
+                    description: "\(Self.errorDescription) -- id: \(errorDescription(for: id))"
+                )
         }
         guard !managed.isDeleted else {
             throw CoreDataError
-                .fetchedObjectIsFlaggedAsDeleted(description: "\(Self.self) -- id: \(errorDescription(for: id))")
+                .fetchedObjectIsFlaggedAsDeleted(
+                    description: "\(Self.errorDescription) -- id: \(errorDescription(for: id))"
+                )
         }
         return managed
     }

--- a/Sources/CoreDataRepository/IdentifiedUnmanagedModel.swift
+++ b/Sources/CoreDataRepository/IdentifiedUnmanagedModel.swift
@@ -45,3 +45,9 @@ extension IdentifiedUnmanagedModel {
         return managed
     }
 }
+
+extension IdentifiedUnmanagedModel where UnmanagedId: CustomStringConvertible {
+    public static func errorDescription(for unmanagedId: UnmanagedId) -> String {
+        unmanagedId.description
+    }
+}

--- a/Sources/CoreDataRepository/ReadableUnmanagedModel.swift
+++ b/Sources/CoreDataRepository/ReadableUnmanagedModel.swift
@@ -80,7 +80,7 @@ extension ReadableUnmanagedModel where Self: ManagedIdReferencable {
     @inlinable
     public func readManaged(from context: NSManagedObjectContext) throws -> ManagedModel {
         guard let managedId else {
-            throw CoreDataError.noObjectIdOnItem(description: "\(Self.self)")
+            throw CoreDataError.noObjectIdOnItem(description: errorDescription)
         }
         return try context.notDeletedObject(for: managedId).asManagedModel()
     }
@@ -90,7 +90,7 @@ extension ReadableUnmanagedModel where Self: ManagedIdUrlReferencable {
     @inlinable
     public func readManaged(from context: NSManagedObjectContext) throws -> ManagedModel {
         guard let managedIdUrl else {
-            throw CoreDataError.noUrlOnItemToMapToObjectId(description: "\(Self.self)")
+            throw CoreDataError.noUrlOnItemToMapToObjectId(description: errorDescription)
         }
         let managedId = try context.objectId(from: managedIdUrl).get()
         return try context.notDeletedObject(for: managedId).asManagedModel()

--- a/Sources/Internal/ModelsWithIntId/IdentifiableModel_Int.swift
+++ b/Sources/Internal/ModelsWithIntId/IdentifiableModel_Int.swift
@@ -105,10 +105,6 @@ extension IdentifiableModel_IntId: IdentifiedUnmanagedModel {
     }
 
     package nonisolated(unsafe) static let unmanagedIdExpression = NSExpression(forKeyPath: \ManagedModel_IntId.id)
-
-    package static func errorDescription(for unmanagedId: Int) -> String {
-        unmanagedId.description
-    }
 }
 
 extension IdentifiableModel_IntId: WritableUnmanagedModel {

--- a/Sources/Internal/ModelsWithUuidId/IdentifiableModel_Uuid.swift
+++ b/Sources/Internal/ModelsWithUuidId/IdentifiableModel_Uuid.swift
@@ -105,10 +105,6 @@ extension IdentifiableModel_UuidId: IdentifiedUnmanagedModel {
     }
 
     package nonisolated(unsafe) static let unmanagedIdExpression = NSExpression(forKeyPath: \ManagedModel_UuidId.id)
-
-    package static func errorDescription(for unmanagedId: UUID) -> String {
-        unmanagedId.uuidString
-    }
 }
 
 extension IdentifiableModel_UuidId: WritableUnmanagedModel {


### PR DESCRIPTION
- Add static errorDescription requirement to `FetchableUnmanagedModel`
    - This enables error descriptions in scenarios where there is no instance of `self` like when a read fails
- Use errorDescription instead of Self.self where possible
- Add default conformance for `unamangeId` error description when UnmanagedId conforms to CustomStringConvertible
    - I've tested this in Align to verify that the default implementation can be overridden